### PR TITLE
Added support for loading a Wix 4 wxs file

### DIFF
--- a/WixEdit.csproj
+++ b/WixEdit.csproj
@@ -657,6 +657,9 @@
     </Compile>
     <Compile Include="src\Xml\XmlDocumentationManager.cs" />
     <Compile Include="src\Xml\XPathHelper.cs" />
+    <EmbeddedResource Include="src\Xsd\wix4.xsd">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">

--- a/WixEdit.csproj
+++ b/WixEdit.csproj
@@ -375,6 +375,7 @@
     <Compile Include="src\EditorForm.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="src\Exceptions\WixBinariesDirectoryFileNotFoundException.cs" />
     <Compile Include="src\Forms\DesignerForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/sample/SimpleSample_WiX4/SimpleSample.wxs
+++ b/sample/SimpleSample_WiX4/SimpleSample.wxs
@@ -1,0 +1,18 @@
+﻿<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="TestProduct" Language="1033" Version="0.0.0.1" Manufacturer="WixEdit" UpgradeCode="4C0C8660-B2A0-4862-8590-8352F6B36FFC" InstallerVersion="200" ProductCode="DEAFBEEF-DEAD-DEAD-DEAD-DEADBEEF0001"><SummaryInformation Description="Test file in a Product" />
+    <Media Id="1" Cabinet="simple.cab" EmbedCab="yes" />
+    
+    <Feature Id="TestProductFeature" Title="Test" Level="1">
+      <ComponentRef Id="TestComponent" />
+    </Feature>
+    <UI />
+  
+      <StandardDirectory Id="ProgramFilesFolder">
+        <Directory Id="TestProduct" Name="TestProduct">
+          <Component Id="TestComponent" Guid="DEAFBEEF-DEAD-DEAD-DEAD-DEADBEEF0003">
+            <File Id="TestFile" Name="Test.txt" KeyPath="yes" DiskId="1" Source="Test.txt" />
+          </Component>
+        </Directory>
+      </StandardDirectory>
+    </Package>
+</Wix>

--- a/sample/SimpleSample_WiX4/Test.txt
+++ b/sample/SimpleSample_WiX4/Test.txt
@@ -1,0 +1,1 @@
+This is a simple test.

--- a/src/EditorForm.cs
+++ b/src/EditorForm.cs
@@ -46,6 +46,7 @@ using System.Threading.Tasks;
 using System.Linq;
 using PInvoke;
 using System.Collections.Generic;
+using WixEdit.src.Exceptions;
 
 namespace WixEdit
 {
@@ -1371,7 +1372,7 @@ namespace WixEdit
                 string wixExeFilePath = WixEditSettings.Instance.WixBinariesDirectory.Wix;
                 if (!File.Exists(wixExeFilePath))
                 {
-                    throw new WixEditException("The executable \"wix.exe\" could not be found.\r\n\r\nPlease specify the correct path to the Wix binaries in the settings dialog.");
+                    throw new WixBinariesDirectoryFileNotFoundException("wix.exe");
                 }
 
                 ProcessStartInfo psiWix = new ProcessStartInfo
@@ -1390,9 +1391,9 @@ namespace WixEdit
             else
             {
                 string candleExe = WixEditSettings.Instance.WixBinariesDirectory.Candle;
-                if (File.Exists(candleExe) == false)
+                if (!File.Exists(candleExe))
                 {
-                    throw new WixEditException("The executable \"candle.exe\" could not be found.\r\n\r\nPlease specify the correct path to the Wix binaries in the settings dialog.");
+                    throw new WixBinariesDirectoryFileNotFoundException("candle.exe");
                 }
 
                 ProcessStartInfo psiCandle = new ProcessStartInfo
@@ -1409,7 +1410,7 @@ namespace WixEdit
                 string lightExe = WixEditSettings.Instance.WixBinariesDirectory.Light;
                 if (File.Exists(lightExe) == false)
                 {
-                    throw new WixEditException("The executable \"light.exe\" could not be found.\r\n\r\nPlease specify the correct path to the Wix binaries in the settings dialog.");
+                    throw new WixBinariesDirectoryFileNotFoundException("light.exe");
                 }
 
                 ProcessStartInfo psiLight = new ProcessStartInfo
@@ -1440,16 +1441,18 @@ namespace WixEdit
             string darkExe = WixEditSettings.Instance.WixBinariesDirectory.Dark;
             if (File.Exists(darkExe) == false)
             {
-                throw new WixEditException("The executable \"dark.exe\" could not be found.\r\n\r\nPlease specify the correct path to the Wix binaries in the settings dialog.");
+                throw new WixBinariesDirectoryFileNotFoundException("dark.exe");
             }
 
-            ProcessStartInfo psiDark = new ProcessStartInfo();
-            psiDark.FileName = darkExe;
-            psiDark.CreateNoWindow = true;
-            psiDark.UseShellExecute = false;
-            psiDark.RedirectStandardOutput = true;
-            psiDark.RedirectStandardError = true;
-            psiDark.Arguments = String.Format("-nologo -x \"{0}\" \"{1}\" \"{2}\"", msiFile.DirectoryName, msiFile.FullName, Path.ChangeExtension(msiFile.FullName, "wxs"));
+            ProcessStartInfo psiDark = new ProcessStartInfo
+            {
+                FileName = darkExe,
+                CreateNoWindow = true,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                Arguments = String.Format("-nologo -x \"{0}\" \"{1}\" \"{2}\"", msiFile.DirectoryName, msiFile.FullName, Path.ChangeExtension(msiFile.FullName, "wxs"))
+            };
 
             ShowOutputPanel();
             outputPanel.Clear();

--- a/src/Exceptions/WixBinariesDirectoryFileNotFoundException.cs
+++ b/src/Exceptions/WixBinariesDirectoryFileNotFoundException.cs
@@ -1,0 +1,10 @@
+﻿namespace WixEdit.src.Exceptions
+{
+    internal class WixBinariesDirectoryFileNotFoundException : WixEditException
+    {
+        public WixBinariesDirectoryFileNotFoundException(string fileName)
+            : base($"The executable \"{fileName}\" could not be found.\r\n\r\nPlease specify the correct path to the Wix binaries in the settings dialog.")
+        {
+        }
+    }
+}

--- a/src/Settings/BinDirectoryStructure.cs
+++ b/src/Settings/BinDirectoryStructure.cs
@@ -34,6 +34,29 @@ namespace WixEdit.Settings {
             wixEditData = data;
         }
 
+        [Editor(typeof(FilteredFileNameEditor), typeof(UITypeEditor))]
+        [FilteredFileNameEditor.Filter("wix.exe |wix.exe")]
+        [Description("The location of the The Windows Installer XML command line tool (wix)")]
+        public string Wix
+        {
+            get
+            {
+                if (wixEditData.WixLocation == null || wixEditData.WixLocation.Length == 0)
+                {
+                    if (wixEditData.BinDirectory == null || wixEditData.BinDirectory.Length == 0)
+                    {
+                        return String.Empty;
+                    }
+                    return Path.Combine(wixEditData.BinDirectory, "tools", "net6.0", "any", "wix.exe");
+                }
+                else
+                {
+                    return wixEditData.WixLocation;
+                }
+            }
+            set { wixEditData.WixLocation = value; }
+        }
+
         [
         DefaultValueAttribute(true),
         Editor(typeof(FilteredFileNameEditor), typeof(System.Drawing.Design.UITypeEditor)),
@@ -121,7 +144,11 @@ namespace WixEdit.Settings {
         }
 
         public bool HasSameBinDirectory() {
-            if (wixEditData.CandleLocation == null && wixEditData.DarkLocation == null && wixEditData.LightLocation == null && wixEditData.XsdsLocation == null) {
+            if (wixEditData.CandleLocation == null
+                && wixEditData.DarkLocation == null
+                && wixEditData.LightLocation == null
+                && wixEditData.XsdsLocation == null)
+            {
                 return true;
             }
 
@@ -186,6 +213,7 @@ namespace WixEdit.Settings {
             public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) {
                 WixEditSettings.WixEditData data = WixEditSettings.Instance.GetInternalDataStructure();
                 data.BinDirectory = value as string;
+                data.WixLocation = String.Empty;
                 data.CandleLocation = String.Empty;
                 data.LightLocation = String.Empty;
                 data.DarkLocation = String.Empty;

--- a/src/Settings/BinDirectoryStructureEditor.cs
+++ b/src/Settings/BinDirectoryStructureEditor.cs
@@ -107,8 +107,10 @@ namespace WixEdit.Settings {
             dialog.SelectedPath = value.BinDirectory;
 
             DialogResult result = dialog.ShowDialog();
-            if(result == DialogResult.OK) {
+            if(result == DialogResult.OK)
+            {
                 value.BinDirectory = dialog.SelectedPath;
+                value.Wix = null;
                 value.Candle = null;
                 value.Xsds = null;
                 value.Dark = null;

--- a/src/Settings/WixEditSettings.cs
+++ b/src/Settings/WixEditSettings.cs
@@ -75,6 +75,7 @@ namespace WixEdit.Settings {
 
             public WixEditData(WixEditData oldVersion, XmlDocument rawData) {
                 BinDirectory = oldVersion.BinDirectory;
+                WixLocation = oldVersion.WixLocation;
                 DarkLocation = oldVersion.DarkLocation;
                 CandleLocation = oldVersion.CandleLocation;
                 LightLocation = oldVersion.LightLocation;
@@ -90,7 +91,11 @@ namespace WixEdit.Settings {
 
                 // Some magic to deal with a new WixEdit installation including a newer WiX version...
                 if (!String.IsNullOrEmpty(BinDirectory) &&
-                    (String.IsNullOrEmpty(DarkLocation) && String.IsNullOrEmpty(CandleLocation) && String.IsNullOrEmpty(LightLocation) && String.IsNullOrEmpty(XsdsLocation)))
+                    (String.IsNullOrEmpty(WixLocation)
+                    && String.IsNullOrEmpty(DarkLocation)
+                    && String.IsNullOrEmpty(CandleLocation)
+                    && String.IsNullOrEmpty(LightLocation)
+                    && String.IsNullOrEmpty(XsdsLocation)))
                 {
                     if (!Directory.Exists(BinDirectory))
                     {
@@ -168,10 +173,11 @@ namespace WixEdit.Settings {
             }
 
             public string BinDirectory;
-            public string DarkLocation;
-            public string CandleLocation;
-            public string LightLocation;
-            public string XsdsLocation;
+            public string WixLocation; // Wix v4
+            public string DarkLocation; // Wix v3
+            public string CandleLocation; // Wix v3
+            public string LightLocation; // Wix v3
+            public string XsdsLocation; // Wix v3
             public string TemplateDirectory;
             public string ExternalXmlEditor;
             public bool UseInstanceOnly;
@@ -391,7 +397,13 @@ namespace WixEdit.Settings {
         ]
         public BinDirectoryStructure WixBinariesDirectory {
             get {
-                if (data.BinDirectory == null && data.CandleLocation == null && data.DarkLocation == null && data.LightLocation == null && data.XsdsLocation == null) {
+                if (data.BinDirectory == null
+                    && data.WixLocation == null
+                    && data.CandleLocation == null
+                    && data.DarkLocation == null
+                    && data.LightLocation == null
+                    && data.XsdsLocation == null)
+                {
                     List<DirectoryInfo> dirs = new List<DirectoryInfo>();
 
                     // With the installation of WixEdit the WiX toolset binaries are installed in "..\wix*", 
@@ -444,9 +456,13 @@ namespace WixEdit.Settings {
                 return new BinDirectoryStructure(data);
             }
             set {
-                if (value.HasSameBinDirectory()) {
+                if (value.HasSameBinDirectory())
+                {
                     data.BinDirectory = new FileInfo(value.Candle).Directory.FullName;
-                } else {
+                }
+                else
+                {
+                    data.WixLocation = value.Wix;
                     data.CandleLocation = value.Candle;
                     data.LightLocation = value.Light;
                     data.DarkLocation = value.Dark;
@@ -464,9 +480,18 @@ namespace WixEdit.Settings {
         public string WixBinariesVersion {
             get {
                 BinDirectoryStructure binaries = WixBinariesDirectory;
-                if (File.Exists(binaries.Candle) == false ||
-                    File.Exists(binaries.Light) == false ||
-                    File.Exists(binaries.Dark) == false) {
+
+                if (File.Exists(binaries.Wix))
+                {
+                    // Wix v4
+                    return FileVersionInfo.GetVersionInfo(binaries.Wix).FileVersion;
+                }
+
+
+                if (!File.Exists(binaries.Candle)
+                    || !File.Exists(binaries.Light)
+                    || !File.Exists(binaries.Dark))
+                {
                     return "(Not all files present)";
                 }
 

--- a/src/Xml/WixFiles.cs
+++ b/src/Xml/WixFiles.cs
@@ -449,12 +449,30 @@ WixFiles.WixNamespaceUri));
 
         public static void ReloadXsd()
         {
+            bool reloadXsd = false;
+
             xsdDocument = new XmlDocument();
 
-            if (File.Exists(WixEditSettings.Instance.GetWixXsdLocation()))
+            if (WixEditSettings.Instance.IsUsingWix4())
+            {
+                // load xsd from embedded resource
+                string resourcePath = "WixEdit.src.Xsd.wix4.xsd";
+
+                Assembly assembly = Assembly.GetExecutingAssembly();
+                Stream xsdStream = assembly.GetManifestResourceStream(resourcePath);
+                xsdDocument.Load(XmlReader.Create(xsdStream));
+
+                reloadXsd = true;
+            }
+            else if (File.Exists(WixEditSettings.Instance.GetWixXsdLocation()))
             {
                 xsdDocument.Load(WixEditSettings.Instance.GetWixXsdLocation());
 
+                reloadXsd = true;
+            }
+
+            if (reloadXsd)
+            {
                 xsdNsmgr = new XmlNamespaceManager(xsdDocument.NameTable);
                 xsdNsmgr.AddNamespace("xs", "http://www.w3.org/2001/XMLSchema");
                 xsdNsmgr.AddNamespace("xse", "http://schemas.microsoft.com/wix/2005/XmlSchemaExtension");
@@ -465,6 +483,12 @@ WixFiles.WixNamespaceUri));
 
         public static bool CheckForXsd()
         {
+            if (WixEditSettings.Instance.IsUsingWix4())
+            {
+                // the Wix 4 xsd is an embedded resource
+                return true;
+            }
+
             return File.Exists(WixEditSettings.Instance.GetWixXsdLocation());
         }
 

--- a/src/Xml/WixFiles.cs
+++ b/src/Xml/WixFiles.cs
@@ -945,6 +945,11 @@ WixFiles.WixNamespaceUri));
             }
         }
 
+        public string GetWixArguments()
+        {
+            return $"build \"{wxsFile.FullName}\" -out \"{OutputFile}\"";
+        }
+
         private string GetCustomCandleArguments()
         {
             string candleArgs = projectSettings.CandleArgs;

--- a/src/Xsd/wix4.xsd
+++ b/src/Xsd/wix4.xsd
@@ -1,0 +1,14282 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xse="http://wixtoolset.org/schemas/XmlSchemaExtension"
+           xmlns:html="http://www.w3.org/1999/xhtml"
+           targetNamespace="http://wixtoolset.org/schemas/v4/wxs"
+           xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <xs:annotation>
+    <xs:documentation>
+      Schema for describing Windows Installer database files (.msi/.msm/.pcp).
+    </xs:documentation>
+    <xs:appinfo>
+      <xse:main />
+    </xs:appinfo>
+  </xs:annotation>
+
+  <xs:element name="Wix">
+    <xs:annotation>
+      <xs:documentation>
+        This is the top-level container element for every wxs file. Among the possible children,
+        the Bundle, Package, Module, Patch, and PatchCreation elements are analogous to the main function in a C program.
+        There can only be one of these present when linking occurs. Package compiles into an msi file,
+        Module compiles into an msm file, PatchCreation compiles into a pcp file. The Fragment element
+        is an atomic unit which ultimately links into either a Package, Module, or PatchCreation. The
+        Fragment can either be completely included or excluded during linking.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:sequence>
+          <xs:choice minOccurs="0">
+            <xs:element ref="Bundle" />
+            <xs:element ref="Package" />
+            <xs:element ref="Module" />
+            <xs:element ref="Patch" />
+            <xs:element ref="PatchCreation" />
+          </xs:choice>
+          <xs:element ref="Fragment" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+      </xs:choice>
+      <xs:attribute name="RequiredVersion" type="WixVersionType">
+        <xs:annotation>
+          <xs:documentation>Required version of the WiX toolset to compile this input file.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Include">
+    <xs:annotation>
+      <xs:documentation>
+        This is the top-level container element for every wxi file.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##any" processContents="lax" />
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Bundle">
+    <xs:annotation>
+      <xs:documentation>The root element for creating bundled packages.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="ApprovedExeForElevation" />
+        <xs:element ref="BootstrapperApplication" />
+        <xs:element ref="BootstrapperApplicationRef" />
+        <xs:element ref="BundleCustomData" />
+        <xs:element ref="BundleCustomDataRef" />
+        <xs:element ref="BundleExtension" />
+        <xs:element ref="BundleExtensionRef" />
+        <xs:element ref="OptionalUpdateRegistration" minOccurs="0" maxOccurs="1" />
+        <xs:element ref="Chain" minOccurs="1" maxOccurs="1" />
+        <xs:element ref="Container" />
+        <xs:element ref="ContainerRef" />
+        <xs:element ref="Log" minOccurs="0" maxOccurs="1" />
+        <xs:element ref="PayloadGroup" />
+        <xs:element ref="PayloadGroupRef" />
+        <xs:element ref="RelatedBundle" />
+        <xs:element ref="Requires" />
+        <xs:element ref="SetVariable" />
+        <xs:element ref="SetVariableRef" />
+        <xs:element ref="SoftwareTag" />
+        <xs:element ref="Update" minOccurs="0" maxOccurs="1" />
+        <xs:element ref="Variable" />
+        <xs:element ref="WixVariable" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="AboutUrl" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            A URL for more information about the bundle to display in Programs and Features (also
+            known as Add/Remove Programs).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Compressed" type="YesNoDefaultTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Whether Packages and Payloads not assigned to a container should be added to the default attached container or if they should be external. The default is yes.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Condition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The condition of the bundle. If the condition is not met, the bundle will
+            refuse to run. Conditions are checked before the bootstrapper application is loaded
+            (before detect), and thus can only reference built-in variables such as
+            variables which indicate the version of the OS.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Copyright" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The legal copyright found in the version resources of final bundle executable. If
+            this attribute is not provided the copyright will be set to "Copyright (c) [Bundle/@Manufacturer]. All rights reserved.".
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DisableModify" type="YesNoButtonTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Determines whether the bundle can be modified via the Programs and Features (also known as
+            Add/Remove Programs). If the value is "button" then Programs and Features will show a single
+            "Uninstall/Change" button. If the value is "yes" then Programs and Features will only show
+            the "Uninstall" button". If the value is "no", the default, then a "Change" button is shown.
+            See the DisableRemove attribute for information how to not display the bundle in Programs
+            and Features.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DisableRemove" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Determines whether the bundle can be removed via the Programs and Features (also
+            known as Add/Remove Programs). If the value is "yes" then the "Uninstall" button will
+            not be displayed. The default is "no" which ensures there is an "Uninstall" button to
+            remove the bundle. If the "DisableModify" attribute is also "yes" or "button" then the
+            bundle will not be displayed in Progams and Features and another mechanism (such as
+            registering as a related bundle addon) must be used to ensure the bundle can be removed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="HelpTelephone" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            A telephone number for help to display in Programs and Features (also known as
+            Add/Remove Programs).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="HelpUrl" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            A URL to the help for the bundle to display in Programs and Features (also known as
+            Add/Remove Programs).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IconSourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Path to an icon that will replace the default icon in the final Bundle executable.
+            This icon will also be displayed in Programs and Features (also known as Add/Remove
+            Programs).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="InProgressName" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Optional name to display in Add/Remove Programs while the bundle is being installed, uninstalled, repaired.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Manufacturer" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The publisher of the bundle to display in Programs and Features (also known as
+            Add/Remove Programs).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The name of the bundle to display in Programs and Features (also known as Add/Remove
+            Programs). This name can be accessed and overwritten by a BootstrapperApplication
+            using the WixBundleName bundle variable.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ParentName" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The name of the parent bundle to display in Installed Updates (also known as Add/Remove
+            Programs). This name is used to nest or group bundles that will appear as updates.
+            If the parent name does not actually exist, a virtual parent is created automatically.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProviderKey" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Optional attribute to explicitly author the provider key for the entire bundle.
+            <html:p>
+              This provider key is designed to persist throughout compatible upgrades so that dependent bundles do not have to be reinstalled
+              and will not prevent your product from being upgraded. If this attribute is not authored, the value is the
+              automatically-generated bundle ID and will not automatically support upgrades.
+            </html:p>
+            <html:p>
+              Only a single provider key is supported for bundles. To author that your bundle provides additional features via
+              packages, author different provider keys for your packages.
+            </html:p>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SplashScreenSourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Path to a bitmap that will be shown as the bootstrapper application is being loaded. If this attribute is not specified, no splash screen will be displayed.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Tag" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Set this string to uniquely identify this bundle to its own BA, and to related bundles. The value of this string only matters to the BA, and its value has no direct effect on engine functionality.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UpdateUrl" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            A URL for updates of the bundle to display in Programs and Features (also
+            known as Add/Remove Programs).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UpgradeCode" type="Guid" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Unique identifier for a family of bundles. If two bundles have the same UpgradeCode the
+            bundle with the highest version will be installed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Version" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The version of the bundle. Newer versions upgrade earlier versions of the bundles
+            with matching UpgradeCodes. If the bundle is registered in Programs and Features
+            then this attribute will be displayed in the Programs and Features user interface.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ApprovedExeForElevation">
+    <xs:annotation>
+      <xs:documentation>Provides information about an .exe so that the BA can request the engine to run it elevated from any secure location.</xs:documentation>
+      <xs:appinfo>
+        <xse:parent namespace="http://wixtoolset.org/schemas/v4/wxs" ref="Bundle" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the ApprovedExeForElevation element.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Key" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The key path.
+            For security purposes, the root key will be HKLM and Variables are not supported.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The value name.
+            For security purposes, Variables are not supported.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Bitness" type="BitnessTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Overrides the default registry to search. The value `always64` will force
+            the search to look in the 64-bit registry even when building for 32-bit.
+            Simliarly, the value `always32` will force the search to look in the 32-bit
+            registry even when building for 64-bit.
+            The default value is `default` where the search will look in the same registry
+            as the bitness of the package.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Log">
+    <xs:annotation>
+      <xs:documentation>Overrides the default log settings for a bundle.</xs:documentation>
+      <xs:appinfo>
+        <xse:parent namespace="http://wixtoolset.org/schemas/v4/wxs" ref="Bundle" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Disable" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Disables the default logging in the Bundle. The end user can still generate a
+            log file by specifying the "-l" command-line argument when installing the
+            Bundle.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PathVariable" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Name of a Variable that will hold the path to the log file. An empty value
+            will cause the variable to not be set. The default is "WixBundleLog".
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Prefix" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            File name and optionally a relative path to use as the prefix for the log file. The
+            default is to use the Bundle/@Name or, if Bundle/@Name is not specified, the value
+            "Setup".
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Extension" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The extension to use for the log. The default is ".log".</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BootstrapperApplicationDll">
+    <xs:annotation>
+      <xs:documentation>Describes the entry point to the bootstrapper application.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The identifier of BootstrapperApplicationDll element.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Location of the source file.
+            The default value is the Name attribute, if provided.
+            At a minimum, the SourceFile or Name attribute must be specified.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The destination path and file name for this payload.
+            The default is the source file name.
+            At a minimum, the Name or SourceFile attribute must be specified.
+            This must be a relative path ('\foo' or 'C:\foo' is not allowed).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DpiAwareness" default="perMonitorV2">
+        <xs:annotation>
+          <xs:documentation>The DPI awareness of the BootstrapperApplication. The default is 'perMonitorV2'. Microsoft High DPI documentation is at https://docs.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="gdiScaled">
+              <xs:annotation>
+                <xs:documentation>Corresponds to the .exe manifest element 'gdiScaling' with content of 'true'. Windows does not support combining this with other DPI awareness modes.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="perMonitor">
+              <xs:annotation>
+               <xs:documentation>Corresponds to the .exe manifest element 'dpiAware' with content of 'true/pm'.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="perMonitorV2">
+              <xs:annotation>
+                <xs:documentation>Corresponds to the .exe manifest element 'dpiAwareness' with content of 'PerMonitorV2, PerMonitor' and the manifest element 'dpiAware' with content of 'true/pm'.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="system">
+              <xs:annotation>
+                <xs:documentation>Corresponds to the .exe manifest element 'dpiAware' with content of 'true'.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="unaware" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              attributes at this point in the schema.
+            </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BootstrapperApplication">
+    <xs:annotation>
+      <xs:documentation>Contains all the relevant information about the setup UI.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="BootstrapperApplicationDll" minOccurs="0" maxOccurs="1" />
+        <xs:element ref="Payload" />
+        <xs:element ref="PayloadGroupRef" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The identifier of the BootstrapperApplication element. Only required if you want to reference this element using a BootstrapperApplicationRef element.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              attributes at this point in the schema.
+            </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BootstrapperApplicationRef">
+    <xs:annotation>
+      <xs:documentation>Used to reference a BootstrapperApplication element and optionally add additional payloads to the bootstrapper application.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Payload" />
+        <xs:element ref="PayloadGroupRef" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the BootstrapperApplication element to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BundleCustomData">
+    <xs:annotation>
+      <xs:documentation>Defines a custom XML element for use in a bundle data manifest.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="BundleAttributeDefinition">
+          <xs:annotation>
+            <xs:documentation>Attribute definition for BundleCustomData. There must be at least one defined.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="BundleElement">
+          <xs:annotation>
+            <xs:documentation>Instance data for BundleCustomData.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Identifier for the custom table.
+            Also used as the name of the XML element.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Type">
+        <xs:annotation>
+          <xs:documentation>
+            Indicates the custom data is transformed into the bootstrapper application data manifest or the bundle extension data manifest.
+            Defaults to BundleExtension if ExtensionId is specified, otherwise BootstrapperApplication.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="BootstrapperApplication" />
+            <xs:enumeration value="BundleExtension" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ExtensionId" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Identifier for the bundle extension.
+            Required when Type is BundleExtension, must not be specified otherwise.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BundleAttributeDefinition">
+    <xs:annotation>
+      <xs:documentation>Attribute definition for BundleCustomData.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The name of the attribute.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BundleElement">
+    <xs:annotation>
+      <xs:documentation>Instance data for BundleCustomData.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="BundleAttribute" maxOccurs="unbounded" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BundleAttribute">
+    <xs:annotation>
+      <xs:documentation>Used for BundleCustomData. Specifies a BundleAttributeDefinition and its value for the parent BundleElement.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Specifies the BundleAttributeDefinition associated with this value.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>An attribute's value.</xs:documentation>
+      </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BundleCustomDataRef">
+    <xs:annotation>
+      <xs:documentation>Used to reference a BundleCustomData element and optionally add more data.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="BundleElement">
+          <xs:annotation>
+            <xs:documentation>Instance data for BundleCustomData.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The identifier of the BundleCustomData element to reference.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BundleExtension">
+    <xs:annotation>
+      <xs:documentation>An extension to the Burn engine. Currently requires a WiX compiler extension to do anything useful.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Payload" />
+        <xs:element ref="PayloadGroupRef" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The identifier of the BundleExtension element. Only required if you want to reference this element using a BundleExtensionRef element.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The relative destination path and file name for the bundle extension DLL.
+            The default is the source file name. Use this attribute to rename the bundle extension DLL or extract it into a subfolder.
+            At a minimum, the Name or SourceFile attribute must be specified.
+            This must be a relative path ('\foo' or 'C:\foo' is not allowed).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The DLL with the bundle extension entry function.
+            The default value is the Name attribute, if provided.
+            At a minimum, the SourceFile or Name attribute must be specified.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BundleExtensionRef">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="BundleExtension" />
+      </xs:appinfo>
+      <xs:documentation>Used to reference a BundleExtension element.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+                Extensibility point in the WiX XML Schema. Schema extensions can register additional
+                elements at this point in the schema.
+              </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the BundleExtension element to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              attributes at this point in the schema.
+            </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="OptionalUpdateRegistration">
+    <xs:annotation>
+      <xs:documentation>Writes additional information to the Windows registry that can be used to detect the bundle.
+      This registration is intended primarily for update to an existing product.</xs:documentation>
+      <xs:appinfo>
+        <xse:remarks>
+          <html:p>The attributes are used to write the following registry values to the key:
+          <html:code>SOFTWARE\[Manufacturer]\Updates\[ProductFamily]\[Name]</html:code></html:p>
+          <html:ul>
+            <html:li>ThisVersionInstalled: Y</html:li>
+            <html:li>PackageName: &gt;bundle name&lt;</html:li>
+            <html:li>PackageVersion: &gt;bundle version&lt;</html:li>
+            <html:li>Publisher: [Manufacturer]</html:li>
+            <html:li>PublishingGroup: [Department]</html:li>
+            <html:li>ReleaseType: [Classification]</html:li>
+            <html:li>InstalledBy: [LogonUser]</html:li>
+            <html:li>InstalledDate: [Date]</html:li>
+            <html:li>InstallerName: &gt;installer name&lt;</html:li>
+            <html:li>InstallerVersion: &gt;installer version&lt;</html:li>
+          </html:ul>
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Manufacturer" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The name of the manufacturer. The default is the Bundle/@Manufacturer attribute,
+          but may also be a short form, ex: Acme instead of Acme Corporation.
+          An error is generated at build time if neither attribute is specified.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Department" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The name of the department or division publishing the update bundle.
+          The PublishingGroup registry value is not written if this attribute is not specified.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProductFamily" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The name of the family of products being updated. The default is the Bundle/@ParentName attribute.
+          The corresponding registry key is not created if neither attribute is specified.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The name of the bundle. The default is the Bundle/@Name attribute,
+          but may also be a short form, ex: KB12345 instead of Update to Product (KB12345).
+          An error is generated at build time if neither attribute is specified.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Classification" type="xs:string" default="Update">
+        <xs:annotation>
+          <xs:documentation>The release type of the update bundle, such as Update, Security Update, Service Pack, etc.
+          The default value is Update.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Chain">
+    <xs:annotation>
+      <xs:documentation>Contains the chain of packages to install.</xs:documentation>
+      <xs:appinfo>
+        <xse:parent namespace="http://wixtoolset.org/schemas/v4/wxs" ref="Bundle" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="MsiPackage" />
+        <xs:element ref="MspPackage" />
+        <xs:element ref="MsuPackage" />
+        <xs:element ref="ExePackage" />
+        <xs:element ref="BundlePackage" />
+        <xs:element ref="RollbackBoundary" />
+        <xs:element ref="PackageGroupRef" />
+      </xs:choice>
+      <xs:attribute name="DisableRollback" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether the bundle will attempt to roll back packages
+            executed in the chain. If "yes" is specified then when a vital
+            package fails to install only that package will roll back and the
+            chain will stop with the error. The default is "no" which
+            indicates all packages executed during the chain will be
+            rolledback to their previous state when a vital package fails.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DisableSystemRestore" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether the bundle will attempt to create a system
+            restore point when executing the chain. If "yes" is specified then
+            a system restore point will not be created. The default is "no" which
+            indicates a system restore point will be created when the bundle is
+            installed, uninstalled, repaired, modified, etc. If the system restore
+            point cannot be created, the bundle will log the issue and continue.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ParallelCache" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether the bundle will start installing packages
+            while other packages are still being cached. If "yes",
+            packages will start executing when a rollback boundary is
+            encountered. The default is "no" which dictates all packages
+            must be cached before any packages will start to be installed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MsiPackage">
+    <xs:annotation>
+      <xs:documentation>Describes a single msi package to install.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="MsiProperty" />
+        <xs:element ref="SlipstreamMsp" />
+        <xs:element ref="Payload" />
+        <xs:element ref="PayloadGroupRef" />
+        <xs:element ref="MsiPackagePayload" />
+        <xs:element ref="Provides" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema. The extension's
+              <html:code>CompilerExtension.ParseElement()</html:code>
+              method will be called with the package identifier as the first value in
+              <html:code>contextValues</html:code>.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attributeGroup ref="ChainPackageCommonAttributes" />
+      <xs:attributeGroup ref="ChainPackagePermanentAttribute" />
+      <xs:attribute name="RepairCondition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            A condition that determines during Repair if the package will be repaired by default.
+            This condition can use built-in variables and variables returned by searches.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="EnableFeatureSelection" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+              Specifies whether the bundle will allow individual control over the installation state of Features inside
+              the msi package. Managing feature selection requires special care to ensure the install, modify, update and
+              uninstall behavior of the package is always correct. The default is "no".
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ForcePerMachine" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+              Override the automatic per-machine detection of MSI packages and force the package to be per-machine.
+              The default is "no", which allows the tools to detect the expected value.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Visible" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether the MSI will be displayed in Programs and Features (also known as Add/Remove Programs). If "yes" is
+            specified the MSI package information will be displayed in Programs and Features. The default "no" indicates the MSI
+            will not be displayed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MspPackage">
+    <xs:annotation>
+      <xs:documentation>Describes a single msp package to install.</xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="SlipstreamMsp" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="MsiProperty" />
+        <xs:element ref="Payload" />
+        <xs:element ref="PayloadGroupRef" />
+        <xs:element ref="MspPackagePayload" />
+        <xs:element ref="Provides" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+                Extensibility point in the WiX XML Schema. Schema extensions can register additional
+                elements at this point in the schema. The extension's
+                <html:code>CompilerExtension.ParseElement()</html:code>
+                method will be called with the package identifier as the first value in
+                <html:code>contextValues</html:code>.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attributeGroup ref="ChainPackageCommonAttributes" />
+      <xs:attributeGroup ref="ChainPackagePermanentAttribute" />
+      <xs:attribute name="RepairCondition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            A condition that determines during Repair if the package will be repaired by default.
+            This condition can use built-in variables and variables returned by searches.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PerMachine" type="YesNoDefaultTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Indicates the package must be executed elevated. The default is "no".</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Slipstream" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether to automatically slipstream the patch for any target msi packages in the chain. The default is "no".
+            Even when the value is "no", you can still author the SlipstreamMsp element under MsiPackage elements as desired.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MsuPackage">
+    <xs:annotation>
+      <xs:documentation>Describes a single msu package to install.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Payload" />
+        <xs:element ref="PayloadGroupRef" />
+        <xs:element ref="MsuPackagePayload" />
+        <xs:element ref="Provides" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+                Extensibility point in the WiX XML Schema. Schema extensions can register additional
+                elements at this point in the schema. The extension's
+                <html:code>CompilerExtension.ParseElement()</html:code>
+                method will be called with the package identifier as the first value in
+                <html:code>contextValues</html:code>.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attributeGroup ref="ChainPackageCommonAttributes" />
+      <xs:attribute name="DetectCondition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            A condition that determines if the package is present on the target system. This condition can use built-in
+            variables and variables returned by searches. This condition is necessary because Windows doesn't provide a
+            method to detect the presence of an MsuPackage. Burn uses this condition to determine how to treat this
+            package during a bundle action; for example, if this condition is false or omitted and the bundle is being
+            installed, Burn will install this package.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ExePackage">
+    <xs:annotation>
+      <xs:documentation>Describes a single exe package to install.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Payload" />
+        <xs:element ref="PayloadGroupRef" />
+        <xs:element ref="ExePackagePayload" />
+        <xs:element ref="ExitCode" />
+        <xs:element ref="CommandLine" />
+        <xs:element ref="ArpEntry" />
+        <xs:element ref="Provides" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema. The extension's
+              <html:code>CompilerExtension.ParseElement()</html:code>
+              method will be called with the package identifier as the first value in
+              <html:code>contextValues</html:code>.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attributeGroup ref="ChainPackageCommonAttributes" />
+      <xs:attributeGroup ref="ChainPackagePermanentAttribute" />
+      <xs:attribute name="DetectCondition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            A condition that determines if the package is present on the target system. This condition can use built-in
+            variables and variables returned by searches. This condition is necessary because Windows doesn't provide a
+            method to detect the presence of an ExePackage. Burn uses this condition to determine how to treat this
+            package during a bundle action; for example, if this condition is false or omitted and the bundle is being
+            installed, Burn will install this package.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RepairCondition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            A condition that determines during Repair if the package will be repaired by default.
+            This condition can use built-in variables and variables returned by searches.
+            This attribute may only be specified if RepairArguments is also specified.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="InstallArguments" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The command-line arguments provided to the ExePackage during install. If this attribute is absent the executable will be launched with no command-line arguments.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RepairArguments" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The command-line arguments to specify to indicate a repair. If the executable package can be repaired but
+            does not require any special command-line arguments to do so then set the attribute's value to blank. To
+            indicate that the package does not support repair, omit this attribute.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UninstallArguments" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The command-line arguments provided to the ExePackage during uninstall. If this attribute is absent the executable will be launched with no command-line arguments. To prevent an ExePackage from being uninstalled set the Permanent attribute to "yes".</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PerMachine" type="YesNoDefaultTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Indicates the package must be executed elevated. The default is "no".</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Bundle" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Indicates the package is a WiX bundle. The default is "no".
+            If "yes", then the default Protocol value is "burn".
+            The engine will prepend command line arguments such as "-norestart" for all operations,
+            as well as avoid running this bundle as a related bundle.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Protocol" type="BurnExeProtocolType">
+        <xs:annotation>
+          <xs:documentation>Indicates the communication protocol the package supports for extended progress and error reporting. The default is "none".</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BundlePackage">
+    <xs:annotation>
+      <xs:documentation>Describes a single bundle package to install.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Payload" />
+        <xs:element ref="PayloadGroupRef" />
+        <xs:element ref="BundlePackagePayload" />
+        <xs:element ref="ExitCode" />
+        <xs:element ref="CommandLine" />
+        <xs:element ref="Provides" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema. The extension's
+              <html:code>CompilerExtension.ParseElement()</html:code>
+              method will be called with the package identifier as the first value in
+              <html:code>contextValues</html:code>.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attributeGroup ref="ChainPackageCommonAttributes" />
+      <xs:attributeGroup ref="ChainPackagePermanentAttribute" />
+      <xs:attribute name="RepairCondition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            A condition that determines during Repair if the package will be repaired by default.
+            This condition can use built-in variables and variables returned by searches.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="InstallArguments" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The command-line arguments provided to the BundlePackage during install.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RepairArguments" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The command-line arguments provided to the BundlePackage during repair.
+            "/repair" is added automatically.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UninstallArguments" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The command-line arguments provided to the BundlePackage during uninstall.
+            "/uninstall" is added automatically.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Visible" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether the bundle will be displayed in Programs and Features (also known as Add/Remove Programs).
+            If "yes" is specified the bundle package information will be displayed in Programs and Features.
+            "no" indicates the bundle will not be displayed.
+            If not specified, the default is the value of the Permanent attribute.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RollbackBoundary">
+    <xs:annotation>
+      <xs:documentation>Describes a rollback boundary in the chain.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema. The extension's
+              <html:code>CompilerExtension.ParseElement()</html:code>
+              method will be called with the rollback boundary identifier as the 'RollbackBoundaryId' key in
+              <html:code>contextValues</html:code>.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Identifier for this rollback boundary, for ordering and cross-referencing. If this attribute is
+            not provided a stable identifier will be generated.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Vital" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether the rollback boundary aborts the chain. The default "yes" indicates that if
+            the rollback boundary is encountered then the chain will fail and roll back or stop. If "no"
+            is specified then the chain should continue successfuly at the next rollback boundary.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="LogPathVariable" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Name of a Variable that will hold the path to the log file when the rollback boundary is a MSI package transaction.
+            An empty value will cause the variable to not be set. The default is "WixBundleLog_[RollbackBoundaryId]".
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Transaction" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether the rollback boundary is wrapped in an MSI transaction. The default is "no".
+            Only MsiPackages and MspPackages may be inside of a rollback boundary with Transaction set to "yes".
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="ChainPackagePermanentAttribute">
+    <xs:attribute name="Permanent" type="YesNoTypeUnion">
+      <xs:annotation>
+        <xs:documentation>
+          Specifies whether the package can be uninstalled. The default is "no".
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="ChainPackageCommonAttributes">
+    <xs:attribute name="SourceFile" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+            Location of the package to add to the bundle.
+            The default value is the Name attribute, if provided.
+            At a minimum, the SourceFile or Name attribute must be specified.
+            Must not be specified if the package payload is given by the *PackagePayload element.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Name" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+            The destination path and file name for this chain payload. Use this attribute to rename the
+            chain entry point or extract it into a subfolder. The default value is the file name from the
+            SourceFile attribute, if provided. At a minimum, the Name or SourceFile attribute must be specified.
+            This must be a relative path ('\foo' or 'C:\foo' is not allowed).
+            Must not be specified if the package payload is given by the *PackagePayload element.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="DownloadUrl" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          <html:p>The URL to use to download the package. The following substitutions are supported:</html:p>
+          <html:ul>
+          <html:li>{0} is replaced by the package Id.</html:li>
+          <html:li>{1} is replaced by the payload Id.</html:li>
+          <html:li>{2} is replaced by the payload file name.</html:li>
+          </html:ul>
+          Must not be specified if the package payload is given by the *PackagePayload element.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Id" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+            Identifier for this package, for ordering and cross-referencing. The default is the Name attribute
+            modified to be suitable as an identifier (i.e. invalid characters are replaced with underscores).
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="After" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+            The identifier of another package that this one should be installed after. By default the After
+            attribute is set to the previous sibling package in the Chain or PackageGroup element. If this
+            attribute is specified ensure that a cycle is not created explicitly or implicitly.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="InstallSize" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+            The size this package will take on disk in bytes after it is installed. By default, the binder will
+            calculate the install size by scanning the package (File table for MSIs, Payloads for EXEs)
+            and use the total for the install size of the package.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="InstallCondition" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          A condition to evaluate before installing the package. The package will only be installed if the condition
+          evaluates to true. If the condition evaluates to false and the bundle is being installed, repaired, or modified,
+          the package will be uninstalled.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Cache" type="KeepRemoveForceTypeUnion">
+      <xs:annotation>
+        <xs:documentation>Whether to cache the package. The default is "keep".</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="CacheId" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>The identifier to use when caching the package.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="DisplayName" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Specifies the display name to place in the bootstrapper application data manifest for the package. By default, ExePackages
+          use the ProductName field from the version information, MsiPackages use the ProductName property, and MspPackages use
+          the DisplayName patch metadata property. Other package types must use this attribute to define a display name in the
+          bootstrapper application data manifest.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Description" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Specifies the description to place in the bootstrapper application data manifest for the package. By default, ExePackages
+          use the FileName field from the version information, MsiPackages use the ARPCOMMENTS property, and MspPackages use
+          the Description patch metadata property. Other package types must use this attribute to define a description in the
+          bootstrapper application data manifest.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="LogPathVariable" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Name of a Variable that will hold the path to the log file. An empty value will cause the variable to not
+          be set. The default is "WixBundleLog_[PackageId]" except for MSU packages which default to no logging.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="RollbackLogPathVariable" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Name of a Variable that will hold the path to the log file used during rollback. An empty value will cause
+          the variable to not be set. The default is "WixBundleRollbackLog_[PackageId]" except for MSU packages which
+          default to no logging.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Vital" type="YesNoTypeUnion">
+      <xs:annotation>
+        <xs:documentation>
+          Specifies whether the package must succeed for the chain to continue. The default "yes"
+          indicates that if the package fails then the chain will fail and roll back or stop. If
+          "no" is specified then the chain will continue even if the package reports failure.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Compressed" type="YesNoDefaultTypeUnion">
+      <xs:annotation>
+        <xs:documentation>
+          Whether the package payload should be embedded in a container or left as an external payload.
+          Must not be specified if the package payload is given by the *PackagePayload element.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:anyAttribute namespace="##other" processContents="lax">
+      <xs:annotation>
+        <xs:documentation>
+          Extensibility point in the WiX XML Schema. Schema extensions can register additional
+          attributes at this point in the schema. The extension's
+          <html:code>CompilerExtension.ParseAttribute()</html:code>
+          method will be called with the package identifier in
+          <html:code>contextValues["PackageId"]</html:code>.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:anyAttribute>
+  </xs:attributeGroup>
+  <xs:element name="PackageGroup">
+    <xs:annotation>
+      <xs:documentation>Describes a package group to a bootstrapper.</xs:documentation>
+      <xs:appinfo>
+        <xse:parent namespace="http://wixtoolset.org/schemas/v4/wxs" ref="Fragment" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="MsiPackage" />
+        <xs:element ref="MspPackage" />
+        <xs:element ref="MsuPackage" />
+        <xs:element ref="ExePackage" />
+        <xs:element ref="BundlePackage" />
+        <xs:element ref="RollbackBoundary" />
+        <xs:element ref="PackageGroupRef" />
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier for package group.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PackageGroupRef">
+    <xs:annotation>
+      <xs:documentation>Create a reference to PackageGroup element that exists inside a Bundle or Fragment element.</xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="PackageGroup" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the PackageGroup element to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="After" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The identifier of a package that this group should be installed after.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MsiProperty">
+    <xs:annotation>
+      <xs:documentation>Allows an MSI property to be set based on the value of a burn engine expression.</xs:documentation>
+      <xs:appinfo>
+        <xse:parent namespace="http://wixtoolset.org/schemas/v4/wxs" ref="MsiPackage" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Name" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The name of the MSI property to set. Burn controls the follow MSI properties so they cannot be set with MsiProperty: ACTION, ALLUSERS, REBOOT, REINSTALL, REINSTALLMODE</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The value to set the property to. This string is evaluated by the burn engine and can be as simple as a burn engine variable reference or as complex as a full expression.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Condition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Condition to determine whether to pass the MSI Property. If this evaluates to false, the MSI Property is not passed along.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SlipstreamMsp">
+    <xs:annotation>
+      <xs:documentation>Specifies a patch included in the same bundle that is installed when the parent MSI package is installed.</xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="MspPackage" />
+        <xse:remarks>
+          <html:p>You can also specify that any MspPackage elements in the chain are automatically slipstreamed by setting the Slipstream attribute of an MspPackage to "yes". This will reduce the amount of authoring you need to write and will determine which msi packages can slipstream patches when building a bundle.</html:p>
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier for a MspPackage in the bundle.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Variable">
+    <xs:annotation>
+      <xs:documentation>Describes a burn engine variable to define.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Hidden" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Whether the value of the variable should be hidden.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The name for the variable.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Persisted" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Whether the variable should be persisted.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Starting value for the variable.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Type" type="VariableType">
+        <xs:annotation>
+          <xs:documentation>Type of the variable, inferred from the value if not specified.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="SearchCommonAttributes">
+    <xs:attribute name="Id" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Id of the search for ordering and dependency.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Variable" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>Name of the variable in which to place the result of the search.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Condition" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Condition for evaluating the search. If this evaluates to false, the search is not executed at all.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="After" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Id of the search that this one should come after.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="SetVariable">
+    <xs:annotation>
+      <xs:documentation>Schedules a "search" that sets a variable to the given value.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="SearchCommonAttributes" />
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            New value for the variable. This string gets formatted, then converted to the specified type, then assigned to the variable.
+            Leaving Value and Type unspecified will clear the variable.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Type" type="VariableType">
+        <xs:annotation>
+          <xs:documentation>Type of the variable, inferred from the value if not specified.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema.  Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SetVariableRef">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="SetVariable" />
+      </xs:appinfo>
+      <xs:documentation>Used to reference a SetVariable element.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the SetVariable element to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Container">
+    <xs:annotation>
+      <xs:documentation>Representation of a file that contains one or more files.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="PackageGroupRef" />
+      </xs:choice>
+      <xs:attribute name="DownloadUrl" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            <html:p>The URL to use to download the container. This attribute is only valid when the container is detached. The
+            following substitutions are supported:</html:p>
+            <html:ul>
+              <html:li>{0} is always null.</html:li>
+              <html:li>{1} is replaced by the container Id.</html:li>
+              <html:li>{2} is replaced by the container file name.</html:li>
+            </html:ul>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The unique identifier for the container. If this attribute is not specified the Name attribute will be used.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The file name for this container. A relative path may be provided to place the container in a sub-folder of the bundle.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Type" type="BurnContainerType">
+        <xs:annotation>
+          <xs:documentation>
+            Indicates whether the container is "attached" to the bundle executable or placed external to the bundle extecutable as "detached". If
+            this attribute is not specified, the default is to create a detached container.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ContainerRef">
+    <xs:annotation>
+      <xs:documentation>Create a reference to an existing Container element.</xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Container" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of Container element to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ArpEntry">
+    <xs:annotation>
+      <xs:documentation>
+        Information about the Add/Remove Programs entry that is installed by the package.
+        ArpEntry may not be specified with DetectCondition or UninstallArguments.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The id of the ARP entry.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Win64" type="YesNoTypeUnion" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Whether the ARP entry is 64-bit.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Version" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The DisplayVersion value of the ARP entry that is installed by this package.
+            Older or missing versions cause this package to be detected as absent.
+            Newer versions cause this package to be detected as obsolete.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ExitCode">
+    <xs:annotation>
+      <xs:documentation>Describes map of exit code returned from executable package to a bootstrapper behavior.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Value" type="NegativeInteger">
+        <xs:annotation>
+          <xs:documentation>Exit code returned from executable package. If no value is provided it means all values not explicitly set default to this behavior.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Behavior" use="required">
+        <xs:annotation>
+          <xs:documentation>Choose one of the supported behaviors error codes: success, error, scheduleReboot, forceReboot, errorScheduleReboot, errorForceReboot.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="success">
+              <xs:annotation>
+                <xs:documentation>The process completed successfully.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="error">
+              <xs:annotation>
+                <xs:documentation>The process failed.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="scheduleReboot">
+              <xs:annotation>
+                <xs:documentation>The process completed successfully and requires the machine to be restarted.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="forceReboot">
+              <xs:annotation>
+                <xs:documentation>The process completed successfully and initiated a restart.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="errorScheduleReboot">
+              <xs:annotation>
+                <xs:documentation>The process failed and requires the machine to be restarted.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="errorForceReboot">
+              <xs:annotation>
+                <xs:documentation>The process failed and initiated a restart.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CommandLine">
+    <xs:annotation>
+      <xs:documentation>Describes additional, conditional command-line arguments for an ExePackage or BundlePackage.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="InstallArgument" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Additional command-line arguments to apply during package installation if Condition is true.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UninstallArgument" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Additional command-line arguments to apply during package uninstallation if Condition is true.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RepairArgument" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Additional command-line arguments to apply during package repair if Condition is true.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Condition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The condition that controls whether the command-line arguments specified in the
+            InstallArgument, UninstallArgument, or RepairArgument attributes are appended to the
+            command line passed to the package. Which attribute is used depends on the
+            action being applied to the package. For example, when the package is
+            being installed, the InstallArgument attribute value is appended to the command
+            line when the package is executed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Payload">
+    <xs:annotation>
+      <xs:documentation>Describes a payload to a bootstrapper.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The identifier of Payload element.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="CertificatePublicKey" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Optional public key of the certificate used to sign the payload. It is not recommended to use this attribute and rely on the Hash alone.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="CertificateThumbprint" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Optional thumbprint of the certificate used to sign the payload. It is not recommended to use this attribute and rely on the Hash alone.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Compressed" type="YesNoDefaultTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Whether the payload should be embedded in a container or left as an external payload.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Hash" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Optional SHA256 hash of the payload. Must be provided if the SourceFile attribute is not used.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Size" type="Integer">
+        <xs:annotation>
+          <xs:documentation>Optional size of the payload in bytes. Required if Hash is specified, otherwise must not be specified.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Location of the source file.
+            The default value is the Name attribute, if provided.
+            At a minimum, the SourceFile or Name attribute must be specified.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The destination path and file name for this payload.
+            The default is the source file name.
+            At a minimum, the Name or SourceFile attribute must be specified.
+            This must be a relative path ('\foo' or 'C:\foo' is not allowed).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DownloadUrl" type="xs:string">
+        <xs:annotation>
+        <xs:documentation>
+          <html:p>The URL to use to download the package. The following substitutions are supported:</html:p>
+          <html:ul>
+          <html:li>{0} is replaced by the package Id.</html:li>
+          <html:li>{1} is replaced by the payload Id.</html:li>
+          <html:li>{2} is replaced by the payload file name.</html:li>
+          </html:ul>
+        </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              attributes at this point in the schema.
+            </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PayloadGroup">
+    <xs:annotation>
+      <xs:documentation>
+        Describes a payload group to a bootstrapper. PayloadGroups referenced from within a Bundle are tied to the Bundle.
+        PayloadGroups referenced from a Fragment are tied to the context of whatever references them such as an ExePackage or MsiPackage.
+        It is possible to share a PayloadGroup between multiple Packages and/or a Bundle by creating multiple references to it.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="BundlePackagePayload" />
+        <xs:element ref="ExePackagePayload" />
+        <xs:element ref="MsiPackagePayload" />
+        <xs:element ref="MspPackagePayload" />
+        <xs:element ref="MsuPackagePayload" />
+        <xs:element ref="Payload" />
+        <xs:element ref="PayloadGroupRef" />
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier for payload group.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PayloadGroupRef">
+    <xs:annotation>
+      <xs:documentation>Create a reference to PayloadGroup element that exists inside a Bundle or Fragment element.</xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="PayloadGroup" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the PayloadGroup element to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BundlePackagePayload">
+    <xs:annotation>
+      <xs:documentation>
+        Describes information about the BundlePackage payload.
+        Cannot be specified if the owning BundlePackage specified any of SourceFile, Name, DownloadUrl, or Compressed.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="RemoteBundle" minOccurs="0" maxOccurs="1" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="PayloadGeneration">
+        <xs:annotation>
+          <xs:documentation>
+            Choose one of the supported payload generation types: none, externalWithoutDownloadUrl, external, all.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="none">
+              <xs:annotation>
+                <xs:documentation>
+                  None of the bundle's payloads or containers are automatically included as payloads for the package.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="externalWithoutDownloadUrl">
+              <xs:annotation>
+                <xs:documentation>
+                  All detached containers from the bundle that have no download url are included as payloads for the package,
+                  as well as all external payloads from the bundle that have no download url.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="external">
+              <xs:annotation>
+                <xs:documentation>
+                  All detached containers from the bundle are included as payloads for the package,
+                  as well as all external payloads from the bundle.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="all">
+              <xs:annotation>
+                <xs:documentation>
+                  All detached containers from the bundle are included as payloads for the package,
+                  as well as all other payloads that are not compressed into the detached containers.
+                  This option normally requires extra work to use since it requires all attached containers to have been extracted.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attributeGroup ref="ChainPackagePayloadCommonAttributes" />
+      <xs:attributeGroup ref="RemotePackagePayloadCommonAttributes" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ExePackagePayload">
+    <xs:annotation>
+      <xs:documentation>
+        Describes information about the ExePackage payload.
+        Cannot be specified if the owning ExePackage specified any of SourceFile, Name, DownloadUrl, or Compressed.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="ChainPackagePayloadCommonAttributes" />
+      <xs:attributeGroup ref="RemotePackagePayloadCommonAttributes" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MsiPackagePayload">
+    <xs:annotation>
+      <xs:documentation>
+        Describes information about the MsiPackage payload.
+        Cannot be specified if the owning MsiPackage specified any of SourceFile, Name, DownloadUrl, or Compressed.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="ChainPackagePayloadCommonAttributes" />
+      <xs:attributeGroup ref="LocalPackagePayloadCommonAttributes" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MspPackagePayload">
+    <xs:annotation>
+      <xs:documentation>
+        Describes information about the MspPackage payload.
+        Cannot be specified if the owning MspPackage specified any of SourceFile, Name, DownloadUrl, or Compressed.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="ChainPackagePayloadCommonAttributes" />
+      <xs:attributeGroup ref="LocalPackagePayloadCommonAttributes" />
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MsuPackagePayload">
+    <xs:annotation>
+      <xs:documentation>
+        Describes information about the MsuPackage payload.
+        Cannot be specified if the owning MsuPackage specified any of SourceFile, Name, DownloadUrl, or Compressed.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attributeGroup ref="ChainPackagePayloadCommonAttributes" />
+      <xs:attributeGroup ref="RemotePackagePayloadCommonAttributes" />
+    </xs:complexType>
+  </xs:element>
+  <xs:attributeGroup name="ChainPackagePayloadCommonAttributes">
+    <xs:attribute name="Id" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>The identifier of the package payload element.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="DownloadUrl" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          <html:p>The URL to use to download the package. The following substitutions are supported:</html:p>
+          <html:ul>
+            <html:li>{0} is replaced by the package Id.</html:li>
+            <html:li>{1} is replaced by the payload Id.</html:li>
+            <html:li>{2} is replaced by the payload file name.</html:li>
+          </html:ul>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Compressed" type="YesNoDefaultTypeUnion">
+      <xs:annotation>
+        <xs:documentation>Whether the package payload should be embedded in a container or left as an external payload.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Name" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          The destination path and file name for this chain payload.
+          Use this attribute to rename the chain entry point or extract it into a subfolder.
+          The default value is the file name from the SourceFile attribute.
+          At a minimum, the Name or SourceFile attribute must be specified.
+          This must be a relative path ('\foo' or 'C:\foo' is not allowed).
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:anyAttribute namespace="##other" processContents="lax" />
+  </xs:attributeGroup>
+  <xs:attributeGroup name="LocalPackagePayloadCommonAttributes">
+    <xs:attribute name="SourceFile" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Location of the package to add to the bundle.
+          The default value is the Name attribute, if provided.
+          At a minimum, the SourceFile or Name attribute must be specified.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:attributeGroup name="RemotePackagePayloadCommonAttributes">
+    <xs:attribute name="SourceFile" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Location of the package to add to the bundle.
+          The default value is the Name attribute, if provided.
+          If Hash is specified, must not be specified.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="CertificatePublicKey" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Optional public key of the certificate used to sign the payload. It is not recommended to use this attribute and rely on the Hash alone.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="CertificateThumbprint" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>Optional thumbprint of the certificate used to sign the payload. It is not recommended to use this attribute and rely on the Hash alone.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Description" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Description of the file from version resources.
+          If Hash is not specified, must not be specified.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Hash" type="HexType">
+      <xs:annotation>
+        <xs:documentation>
+          SHA-512 hash of the RemotePayload.
+          If SourceFile is specified, must not be specified.
+          If specified then Name, DownloadUrl, and Size are required.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="ProductName" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>
+          Product name of the file from version resouces.
+          If Hash is not specified, must not be specified.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Size" type="Integer">
+      <xs:annotation>
+        <xs:documentation>
+          Size of the remote file in bytes.
+          Required if Hash is specified, otherwise must not be specified.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Version" type="WixVersionType">
+      <xs:annotation>
+        <xs:documentation>
+          Version of the remote file.
+          If Hash is not specified, must not be specified.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:element name="RemoteBundle">
+    <xs:annotation>
+      <xs:documentation>
+        Describes information about the referenced Bundle.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="RemoteRelatedBundle" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="BundleId" type="Guid" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The id of the bundle.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DisplayName" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The display name of the bundle.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="EngineVersion" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The version of the bundle's engine.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="InstallSize" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The size this bundle will take on disk in bytes after it is installed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ManifestNamespace" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The namespace of the bundle's manifest.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PerMachine" type="YesNoTypeUnion" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Whether the bundle is per-machine.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProtocolVersion" type="Integer" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The protocol version of the related bundle.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProviderKey" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The provider key of the bundle.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UpgradeCode" type="Guid" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            An upgrade code of the bundle.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Version" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The version of the bundle.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Win64" type="YesNoTypeUnion" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Whether the bundle is 64-bit.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RemoteRelatedBundle">
+    <xs:annotation>
+      <xs:documentation>
+        Defines a related bundle for the parent RemoteBundle.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="Guid" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the RelatedBundle group.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Action" use="required">
+        <xs:annotation>
+          <xs:documentation>The action to take on bundles related to this one.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="detect" />
+            <xs:enumeration value="upgrade" />
+            <xs:enumeration value="addon" />
+            <xs:enumeration value="patch" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RelatedBundle">
+    <xs:annotation>
+      <xs:documentation>Defines a related bundle for the parent Bundle.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="Guid" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the RelatedBundle group.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Action" use="optional">
+        <xs:annotation>
+          <xs:documentation>The action to take on bundles related to this one. Detect is the default.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="detect" />
+            <xs:enumeration value="upgrade" />
+            <xs:enumeration value="addon" />
+            <xs:enumeration value="patch" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Update">
+    <xs:annotation>
+      <xs:documentation>Defines the update for a Bundle.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Location" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The absolute path or URL to check for an update bundle. Currently the engine provides this value
+            in the IBootstrapperApplication::OnDetectUpdateBegin() and otherwise ignores the value. In the
+            future the engine will be able to acquire an update bundle from the location and determine if it
+            is newer than the current executing bundle.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Package">
+    <xs:annotation>
+      <xs:documentation>
+        The Package element is analogous to the main function in a C program. When linking, only one Package section
+        can be given to the linker to produce a successful result. Using this element creates an MSI file.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:remarks>
+          <html:p>You can specify any valid Windows code page by integer like 1252, or by web name like Windows-1252. See [Code pages](../../tools/codepage.md) for more information.</html:p>
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="AdminExecuteSequence" />
+        <xs:element ref="AdminUISequence" />
+        <xs:element ref="AdvertiseExecuteSequence" />
+        <xs:element ref="AppId" />
+        <xs:element ref="Binary" />
+        <xs:element ref="ComplianceCheck" />
+        <xs:element ref="Component" />
+        <xs:element ref="ComponentGroup" />
+        <xs:element ref="CustomAction" />
+        <xs:element ref="CustomActionRef" />
+        <xs:element ref="CustomTable" />
+        <xs:element ref="CustomTableRef" />
+        <xs:element ref="Directory" />
+        <xs:element ref="DirectoryRef" />
+        <xs:element ref="EmbeddedChainer" />
+        <xs:element ref="EmbeddedChainerRef" />
+        <xs:element ref="EnsureTable" />
+        <xs:element ref="Feature" />
+        <xs:element ref="FeatureRef" />
+        <xs:element ref="FeatureGroupRef" />
+        <xs:element ref="Icon" />
+        <xs:element ref="InstallExecuteSequence" />
+        <xs:element ref="InstallUISequence" />
+        <xs:element ref="InstanceTransforms" />
+        <xs:element ref="Launch" />
+        <xs:element ref="MajorUpgrade" />
+        <xs:element ref="Media" />
+        <xs:element ref="MediaTemplate" />
+        <xs:element ref="PackageCertificates" />
+        <xs:element ref="PatchCertificates" />
+        <xs:element ref="Property" />
+        <xs:element ref="PropertyRef" />
+        <xs:element ref="Requires" />
+        <xs:element ref="SetDirectory" />
+        <xs:element ref="SetProperty" />
+        <xs:element ref="SFPCatalog" />
+        <xs:element ref="SoftwareTag" />
+        <xs:element ref="StandardDirectory" />
+        <xs:element ref="SummaryInformation" />
+        <xs:element ref="SymbolPath" />
+        <xs:element ref="UI" />
+        <xs:element ref="UIRef" />
+        <xs:element ref="Upgrade" />
+        <xs:element ref="WixVariable" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Codepage" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The code page integer value or web name for the resulting MSI. See remarks for more information.
+            The default codepage is 65001 (UTF-8).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Compressed" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Indicates whether the package files are compressed. Default is compressed packages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="InstallerVersion" type="Integer">
+        <xs:annotation>
+          <xs:documentation>
+            The minimum version of the Windows Installer required to install this package. Take the major version of the required Windows Installer
+            and multiply by a 100 then add the minor version of the Windows Installer. For example, "200" would represent Windows Installer 2.0 and
+            "405" would represent Windows Installer 4.5. This value is defaulted to "500" which is the latest version of the Windows Installer and
+            present in Windows 7 and later.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Language" type="LocalizableInteger">
+        <xs:annotation>
+          <xs:documentation>The decimal language ID (LCID) for the product.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Manufacturer" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The manufacturer of the package.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The descriptive name of the product.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProductCode" type="AutogenGuid">
+        <xs:annotation>
+          <xs:documentation>
+            Optional ProductCode GUID for the package. By default, a new ProductCode will be
+            generated with every build enabling major upgrades.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Scope" type="PackageScopeTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Use this attribute to specify the installation scope of this package: per-machine, per-user, or a choice of either.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ShortNames" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Indicates whether the package files are installed using 8.3 filenames.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UpgradeCode" type="Guid">
+        <xs:annotation>
+          <xs:documentation>The upgrade code GUID for the product.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Version" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The product's version string.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Module">
+    <xs:annotation>
+      <xs:documentation>
+        The Module element is analogous to the main function in a C program. When linking, only
+        one Module section can be given to the linker to produce a successful result. Using this
+        element creates an msm file.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="AppId" />
+        <xs:element ref="Binary" />
+        <xs:element ref="Component" />
+        <xs:element ref="ComponentGroupRef" />
+        <xs:element ref="ComponentRef" />
+        <xs:element ref="Configuration" />
+        <xs:element ref="CustomAction" />
+        <xs:element ref="CustomActionRef" />
+        <xs:element ref="CustomTable" />
+        <xs:element ref="CustomTableRef" />
+        <xs:element ref="Dependency" />
+        <xs:element ref="Directory" />
+        <xs:element ref="DirectoryRef" />
+        <xs:element ref="EmbeddedChainer" />
+        <xs:element ref="EmbeddedChainerRef" />
+        <xs:element ref="EnsureTable" />
+        <xs:element ref="Exclusion" />
+        <xs:element ref="Icon" />
+        <xs:element ref="IgnoreTable" />
+        <xs:element ref="Property" />
+        <xs:element ref="PropertyRef" />
+        <xs:element ref="Requires" />
+        <xs:element ref="SetDirectory" />
+        <xs:element ref="SetProperty" />
+        <xs:element ref="SFPCatalog" />
+        <xs:element ref="StandardDirectory" />
+        <xs:element ref="Substitution" />
+        <xs:element ref="SummaryInformation" />
+        <xs:element ref="UI" />
+        <xs:element ref="UIRef" />
+        <xs:element ref="WixVariable" />
+        <xs:element ref="InstallExecuteSequence" />
+        <xs:element ref="InstallUISequence" />
+        <xs:element ref="AdminExecuteSequence" />
+        <xs:element ref="AdminUISequence" />
+        <xs:element ref="AdvertiseExecuteSequence" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The name of the merge module (not the file name).</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Codepage" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The code page integer value or web name for the resulting MSM. You can specify any valid Windows
+            code by by integer like 1252, or by web name like Windows-1252. See [Code pages](../../tools/codepage.md)
+            for more information.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Guid" type="Guid">
+        <xs:annotation>
+          <xs:documentation>The GUID of the Merge Module that will be appended to primary keys in the database.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="InstallerVersion" type="Integer">
+        <xs:annotation>
+          <xs:documentation>
+            The minimum version of the Windows Installer required to install this package. Take the major version of the required Windows Installer
+            and multiply by a 100 then add the minor version of the Windows Installer. For example, "200" would represent Windows Installer 2.0 and
+            "405" would represent Windows Installer 4.5. This value is defaulted to "500" which is the latest version of the Windows Installer and
+            present in Windows 7 and later.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Language" type="LocalizableInteger" use="required">
+        <xs:annotation>
+          <xs:documentation>The decimal language ID (LCID) of the merge module.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Version" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The major and minor versions of the merge module.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Dependency">
+    <xs:annotation>
+      <xs:documentation>Declares a dependency on another merge module.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="RequiredId" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier of the merge module required by the merge module.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RequiredLanguage" type="Integer" use="required">
+        <xs:annotation>
+          <xs:documentation>Numeric language ID of the merge module in RequiredID.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RequiredVersion" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Version of the merge module in RequiredID.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Exclusion">
+    <xs:annotation>
+      <xs:documentation>Declares a merge module with which this merge module is incompatible.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="ExcludedId" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier of the merge module that is incompatible.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ExcludeExceptLanguage" type="Integer">
+        <xs:annotation>
+          <xs:documentation>Numeric language ID of the merge module in ExcludedID. All except this language will be excluded. Only one of ExcludeExceptLanguage and ExcludeLanguage may be specified.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ExcludeLanguage" type="Integer">
+        <xs:annotation>
+          <xs:documentation>Numeric language ID of the merge module in ExcludedID. The specified language will be excluded. Only one of ExcludeExceptLanguage and ExcludeLanguage may be specified.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ExcludedMinVersion" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Minimum version excluded from a range. If not set, all versions before max are excluded. If neither max nor min, no exclusion based on version.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ExcludedMaxVersion" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Maximum version excluded from a range. If not set, all versions after min are excluded. If neither max nor min, no exclusion based on version.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Configuration">
+    <xs:annotation>
+      <xs:documentation>Defines the configurable attributes of merge module.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Name" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Defines the name of the configurable item.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Format" use="required">
+        <xs:annotation>
+          <xs:documentation>Specifies the format of the data being changed.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="Text" />
+            <xs:enumeration value="Key" />
+            <xs:enumeration value="Integer" />
+            <xs:enumeration value="Bitfield" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Type" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Specifies the type of the data being changed.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ContextData" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Specifies a semantic context for the requested data.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DefaultValue" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Specifies a default value for the item in this record if the merge tool declines to provide a value.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="KeyNoOrphan" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Does not merge rule according to rules in MSI SDK.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="NonNullable" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>If yes, null is not a valid entry.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DisplayName" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Display name for authoring.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Description" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Description for authoring.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="HelpLocation" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Location of chm file for authoring.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="HelpKeyword" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Keyword into chm file for authoring.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Substitution">
+    <xs:annotation>
+      <xs:documentation>Specifies the configurable fields of a module database and provides a template for the configuration of each field.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Table" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Specifies the name of the table being modified in the module database.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Row" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Specifies the primary keys of the target row in the table named in the Table column. If multiple keys, separated by semicolons.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Column" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Specifies the target column in the row named in the Row column.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Provides a formatting template for the data being substituted into the target field specified by Table, Row, and Column.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="IgnoreTable">
+    <xs:annotation>
+      <xs:documentation>
+                Specifies a table from the merge module that is not merged into an .msi file.
+                If the table already exists in an .msi file, it is not modified by the merge.
+                The specified table can therefore contain data that is unneeded after the merge.
+                To minimize the size of the .msm file, it is recommended that developers remove
+                unused tables from modules intended for redistribution rather than creating
+                IgnoreTable elements for those tables.
+            </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+                        The name of the table in the merge module that is not to be merged into the .msi file.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Fragment">
+    <xs:annotation>
+      <xs:documentation>
+                The Fragment element is the building block of creating an installer database in WiX. Once defined,
+                the Fragment becomes an immutable, atomic unit which can either be completely included or excluded
+                from a product. The contents of a Fragment element can be linked into a product by utilizing one
+                of the many *Ref elements. When linking in a Fragment, it will be necessary to link in all of its
+                individual units. For instance, if a given Fragment contains two Component elements, you must link
+                both under features using ComponentRef for each linked Component. Otherwise, you will get a linker
+                warning and have a floating Component that does not appear under any Feature.
+            </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="AdminExecuteSequence" />
+        <xs:element ref="AdminUISequence" />
+        <xs:element ref="AdvertiseExecuteSequence" />
+        <xs:element ref="AppId" />
+        <xs:element ref="Binary" />
+        <xs:element ref="BootstrapperApplication" />
+        <xs:element ref="BootstrapperApplicationRef" />
+        <xs:element ref="BundleCustomData" />
+        <xs:element ref="BundleCustomDataRef" />
+        <xs:element ref="BundleExtension" />
+        <xs:element ref="BundleExtensionRef" />
+        <xs:element ref="ComplianceCheck" />
+        <xs:element ref="Component" />
+        <xs:element ref="ComponentGroup" />
+        <xs:element ref="Container" />
+        <xs:element ref="CustomAction" />
+        <xs:element ref="CustomActionRef" />
+        <xs:element ref="CustomTable" />
+        <xs:element ref="CustomTableRef" />
+        <xs:element ref="Directory" />
+        <xs:element ref="DirectoryRef" />
+        <xs:element ref="EmbeddedChainer" />
+        <xs:element ref="EmbeddedChainerRef" />
+        <xs:element ref="EnsureTable" />
+        <xs:element ref="Feature" />
+        <xs:element ref="FeatureGroup" />
+        <xs:element ref="FeatureRef" />
+        <xs:element ref="Icon" />
+        <xs:element ref="InstallExecuteSequence" />
+        <xs:element ref="InstallUISequence" />
+        <xs:element ref="Launch" />
+        <xs:element ref="Media" />
+        <xs:element ref="MediaTemplate" />
+        <xs:element ref="PackageGroup" />
+        <xs:element ref="PackageCertificates" />
+        <xs:element ref="PatchCertificates" />
+        <xs:element ref="PatchFamily" />
+        <xs:element ref="PatchFamilyGroup"/>
+        <xs:element ref="PatchFamilyGroupRef"/>
+        <xs:element ref="PayloadGroup" />
+        <xs:element ref="Property" />
+        <xs:element ref="PropertyRef" />
+        <xs:element ref="RelatedBundle" />
+        <xs:element ref="Requires" />
+        <xs:element ref="SetDirectory" />
+        <xs:element ref="SetProperty" />
+        <xs:element ref="SetVariable" />
+        <xs:element ref="SetVariableRef" />
+        <xs:element ref="SFPCatalog" />
+        <xs:element ref="StandardDirectory" />
+        <xs:element ref="UI" />
+        <xs:element ref="UIRef" />
+        <xs:element ref="Upgrade" />
+        <xs:element ref="Variable" />
+        <xs:element ref="WixVariable" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Optional identifier for a Fragment. Should only be set by advanced users to tag sections.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Patch">
+    <xs:annotation>
+      <xs:documentation>
+            The Patch element is analogous to the main function in a C program. When linking, only one Patch section
+            can be given to the linker to produce a successful result. Using this element creates an MSP file.
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:remarks>
+          <html:p>You can specify any valid Windows code by by integer like 1252, or by web name like Windows-1252. See [Code pages](../../tools/codepage.md) for more information.</html:p>
+          <html:p>The ClientPatchId attribute allows you to specify an easily referenced identity that you can use in product authoring. This identity prefixes properties added by WiX to a patch transform, such as <html:i>ClientPatchId</html:i>.PatchCode and <html:i>ClientPatchId</html:i>.AllowRemoval. If the patch code GUID is auto-generated you could not reference any properties using this auto-generated prefix.</html:p>
+          <html:p>For example, if you were planning to ship a patch referred to as "QFE1" and needed to write your own registry values for Add/Remove Programs in product authoring such as the UninstallString for this patch, you could author a RegistryValue with the name UninstallString and the value <html:code>[SystemFolder]msiexec.exe /package [ProductCode] /uninstall [QFE1.PatchCode]</html:code>. In your patch authoring you would then set ClientPatchId to "QFE1" and WiX will add the QFE1.PatchCode property to the patch transform when the patch is created. If the Id attribute specified the patch code to be generated automatically, you could not reference the <html:i>prefix</html:i>.PatchCode property as shown above.</html:p>
+          <html:p>The summary information is automatically populated from attribute values of the Patch element including the code page. If you want to override some of these summary information properties or use a different code page for the summary information itself, author the PatchInformation element.</html:p>
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="PatchInformation" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Optional element that allows overriding summary information properties.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element ref="Media" minOccurs="1" maxOccurs="unbounded" />
+          <xs:element ref="OptimizeCustomActions" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Indicates whether custom actions can be skipped when applying the patch.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element ref="PatchFamily" minOccurs="1" maxOccurs="unbounded" />
+          <xs:element ref="PatchFamilyRef" minOccurs="0" maxOccurs="unbounded" />
+          <xs:element ref="PatchFamilyGroup" minOccurs="1" maxOccurs="unbounded"/>
+          <xs:element ref="PatchFamilyGroupRef" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element ref="PatchProperty" />
+          <xs:element ref="TargetProductCodes" />
+          <xs:any namespace="##other" processContents="lax">
+            <xs:annotation>
+              <xs:documentation>
+                            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+                            elements at this point in the schema.
+                        </xs:documentation>
+            </xs:annotation>
+          </xs:any>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="Id" type="AutogenGuid">
+        <xs:annotation>
+          <xs:documentation>Patch code for this patch.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Codepage" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The code page integer value or web name for the resulting MSP. See remarks for more information.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="AllowRemoval" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Whether this is an uninstallable patch.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Classification" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Category of updates. Recommended values are Critical Update, Hotfix, Security Rollup, Security Update, Service Pack, Update, Update Rollup.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ClientPatchId" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>An easily referenced identity unique to a patch that can be used in product authoring. See remarks for more information.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ApiPatchingSymbolNoImagehlpFlag" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Flag used when creating a binary file patch. Default is "no". Don't use imagehlp.dll.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ApiPatchingSymbolNoFailuresFlag" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Flag used when creating a binary file patch. Default is "no". Don't fail patch due to imagehlp failures.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ApiPatchingSymbolUndecoratedTooFlag" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Flag used when creating a binary file patch. Default is "no". After matching decorated symbols, try to match remaining by undecorated names.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Description" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Description of the patch.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DisplayName" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>A title for the patch that is suitable for public display. In Add/Remove Programs from XP SP2 on.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Comments" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Optional comments for browsing.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Manufacturer" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Vendor releasing the package</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MinorUpdateTargetRTM" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    Indicates that the patch targets the RTM version of the product or the most recent major
+                    upgrade patch. Author this optional property in minor update patches that contain sequencing
+                    information to indicate that the patch removes all patches up to the RTM version of the
+                    product, or up to the most recent major upgrade patch. This property is available beginning
+                    with Windows Installer 3.1.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MoreInfoURL" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>A URL that provides information specific to this patch. In Add/Remove Programs from XP SP2 on.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OptimizedInstallMode" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    If this attribute is set to 'yes' in all the patches to be applied in a transaction, the
+                    application of the patch is optimized if possible. Available beginning with Windows Installer 3.1.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="TargetProductName" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Name of the application or target product suite.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OptimizePatchSizeForLargeFiles" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>When this attribute is set, patches for files greater than approximately 4 MB in size may be made smaller.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Validate">
+    <xs:annotation>
+      <xs:documentation>Sets information in the patch transform that determines if the transform applies to an installed product and what errors should be ignored when applying the patch transform.</xs:documentation>
+      <xs:appinfo>
+        <xse:remarks>
+          <html:p>A transform contains the differences between the target product and the upgraded product. When a transform or a patch (which contains transforms) is applied, the following properties of the installed product are validated against the properties of the target product stored in a transform.</html:p>
+          <html:ul>
+            <html:li>ProductCode</html:li>
+            <html:li>ProductLanguage</html:li>
+            <html:li>ProductVersion</html:li>
+            <html:li>UpgradeCode</html:li>
+          </html:ul>
+          <html:p>Windows Installer simply validates that the ProductCode, ProductLanguage, and UpgradeCode of an installed product are equivalent to those propeties of the target product used to create the transform; however, the ProductVersion can be validated with a greater range of comparisons.</html:p>
+          <html:p>You can compare up to the first three fields of the ProductVersion. Changes to the fourth field are not validated and are useful for small updates. You can also choose how to compare the target ProductVersion used to create the transform with the installed ProductVersion. For example, while the default value of 'Equals' is recommended, if you wanted a minor upgrade patch to apply to the target ProductVersion and all older products with the same ProductCode, you would use 'LesserOrEqual'.</html:p>
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="ProductId" type="YesNoTypeUnion" default="yes">
+        <xs:annotation>
+          <xs:documentation>Requires that the installed ProductCode match the target ProductCode used to create the transform. The default is 'yes'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProductLanguage" type="YesNoTypeUnion" default="no">
+        <xs:annotation>
+          <xs:documentation>Requires that the installed ProductLanguage match the target ProductLanguage used to create the transform. The default is 'no'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProductVersion" default="Update">
+        <xs:annotation>
+          <xs:documentation>Determines how many fields of the installed ProductVersion to compare. See remarks for more information. The default is 'Update'.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="Major">
+              <xs:annotation>
+                <xs:documentation>Checks the major version.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Minor">
+              <xs:annotation>
+                <xs:documentation>Checks the major and minor versions.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Update">
+              <xs:annotation>
+                <xs:documentation>Checks the major, minor, and update versions.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ProductVersionOperator" default="Equal">
+        <xs:annotation>
+          <xs:documentation>Determines how the installed ProductVersion is compared to the target ProductVersion used to create the transform. See remarks for more information. The default is 'Equal'.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="Lesser">
+              <xs:annotation>
+                <xs:documentation>Installed ProductVersion &lt; target ProductVersion.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="LesserOrEqual">
+              <xs:annotation>
+                <xs:documentation>Installed ProductVersion &lt;= target ProductVersion.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Equal">
+              <xs:annotation>
+                <xs:documentation>Installed ProductVersion = target ProductVersion.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="GreaterOrEqual">
+              <xs:annotation>
+                <xs:documentation>Installed ProductVersion &gt;= target ProductVersion.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="Greater">
+              <xs:annotation>
+                <xs:documentation>Installed ProductVersion &gt; target ProductVersion.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="UpgradeCode" type="YesNoTypeUnion" default="yes">
+        <xs:annotation>
+          <xs:documentation>Requires that the installed UpgradeCode match the target UpgradeCode used to create the transform. The default is 'yes'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreAddExistingRow" type="YesNoTypeUnion" default="yes">
+        <xs:annotation>
+          <xs:documentation>Ignore errors when adding existing rows. The default is 'yes'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreAddExistingTable" type="YesNoTypeUnion" default="yes">
+        <xs:annotation>
+          <xs:documentation>Ignore errors when adding existing tables. The default is 'yes'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreDeleteMissingRow" type="YesNoTypeUnion" default="yes">
+        <xs:annotation>
+          <xs:documentation>Ignore errors when deleting missing rows. The default is 'yes'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreDeleteMissingTable" type="YesNoTypeUnion" default="yes">
+        <xs:annotation>
+          <xs:documentation>Ignore errors when deleting missing tables. The default is 'yes'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreUpdateMissingRow" type="YesNoTypeUnion" default="yes">
+        <xs:annotation>
+          <xs:documentation>Ignore errors when updating missing rows. The default is 'yes'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreChangingCodePage" type="YesNoTypeUnion" default="no">
+        <xs:annotation>
+          <xs:documentation>Ignore errors when changing the database code page. The default is 'no'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="OptimizeCustomActions">
+    <xs:annotation>
+      <xs:documentation>Indicates whether custom actions can be skipped when applying the patch.</xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiPatchMetadata" href="http://msdn.microsoft.com/library/aa370344.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="SkipAssignment" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Skip property (type 51) and directory (type 35) assignment custom actions.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SkipImmediate" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Skip immediate custom actions that are not property or directory assignment custom actions.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SkipDeferred" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Skip custom actions that run within the script.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PatchBaseline">
+    <xs:annotation>
+      <xs:documentation>Identifies a set of product versions.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:element ref="Validate" minOccurs="0" />
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier for a set of product versions. It is recommended to use short identifiers like 'RTM' and 'SP1'. The identifier will been trimmed to less than 28 characters as required by the Windows Installer.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="BaselineFile" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Path to baseline MSI for patch.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UpdateFile" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Path to updated MSI for patch.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DiskId" type="Integer">
+        <xs:annotation>
+          <xs:documentation>Optional id for cabinet to place patched files in.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PatchFamily">
+    <xs:annotation>
+      <xs:documentation>Collection of items that should be kept from the differences between two products.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="All" minOccurs="0" />
+        <xs:element ref="BinaryRef" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element ref="ComponentRef" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element ref="CustomActionRef" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element ref="DigitalCertificateRef" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element ref="DirectoryRef" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element ref="FeatureRef" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element ref="IconRef" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element ref="PropertyRef" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element ref="SoftwareTagRef" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element ref="UIRef" minOccurs="0" maxOccurs="unbounded" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier which indicates a sequence family to which this patch belongs.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProductCode" type="Guid">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the ProductCode of the product that this family applies to.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Version" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Used to populate the sequence column of the MsiPatchSequence table in the final MSP file.
+            Specified in x.x.x.x format. See documentation for Sequence column of MsiPatchSequence table in MSI SDK.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Supersede" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Set this value to 'yes' to indicate that this patch will supersede all previous patches in this patch family.
+            The default value is 'no'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PatchFamilyGroup">
+    <xs:annotation>
+      <xs:documentation>
+        Groups together multiple patch families to be used in other locations.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="PatchFamilyGroupRef"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="PatchFamily"/>
+        <xs:element ref="PatchFamilyRef"/>
+        <xs:element ref="PatchFamilyGroupRef"/>
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier for the PatchFamilyGroup.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:anyAttribute>
+  </xs:complexType>
+</xs:element>
+<xs:element name="PatchFamilyGroupRef">
+  <xs:annotation>
+      <xs:documentation>Create a reference to a PatchFamilyGroup in another Fragment.</xs:documentation>
+      <xs:appinfo>
+          <xse:seeAlso ref="PatchFamilyGroup" />
+      </xs:appinfo>
+  </xs:annotation>
+  <xs:complexType>
+    <xs:attribute name="Id" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>The identifier of the PatchFamilyGroup to reference.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:anyAttribute namespace="##other" processContents="lax">
+      <xs:annotation>
+        <xs:documentation>
+          Extensibility point in the WiX XML Schema. Schema extensions can register additional
+          attributes at this point in the schema.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:anyAttribute>
+  </xs:complexType>
+</xs:element>
+  <xs:element name="PatchCreation">
+    <xs:annotation>
+      <xs:documentation>
+            The PatchCreation element is analogous to the main function in a C program. When linking, only one PatchCreation section
+            can be given to the linker to produce a successful result. Using this element creates a pcp file.
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:remarks>
+          <html:p>You can specify any valid Windows code by by integer like 1252, or by web name like Windows-1252. See [Code pages](../../tools/codepage.md) for more information.</html:p>
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="PatchInformation" />
+        <xs:element ref="PatchMetadata" minOccurs="0" />
+        <xs:element ref="Family" maxOccurs="unbounded" />
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="PatchProperty" />
+          <xs:element ref="PatchSequence" />
+          <xs:element ref="ReplacePatch" />
+          <xs:element ref="TargetProductCode" />
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="Id" type="Guid" use="required">
+        <xs:annotation>
+          <xs:documentation>PatchCreation identifier; this is the primary key for identifying patches.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="AllowMajorVersionMismatches" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Use this to set whether the major versions between the upgrade and target images match. See <html:a href="http://msdn.microsoft.com/library/aa370890.aspx">AllowProductVersionMajorMismatches</html:a> for more information.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="AllowProductCodeMismatches" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Use this to set whether the product code between the upgrade and target images match. See <html:a href="http://msdn.microsoft.com/library/aa370890.aspx">AllowProductCodeMismatches</html:a> for more information.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="CleanWorkingFolder" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Use this to set whether Patchwiz should clean the temp folder when finished. See <html:a href="http://msdn.microsoft.com/library/aa370890.aspx">DontRemoveTempFolderWhenFinished</html:a> for more information.	</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Codepage" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The code page integer value or web name for the resulting PCP. See remarks for more information.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OutputPath" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The full path, including file name, of the patch package file that is to be generated. See <html:a href="http://msdn.microsoft.com/library/aa370890.aspx">PatchOutputPath</html:a> for more information.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceList" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Used to locate the .msp file for the patch if the cached copy is unavailable. See <html:a href="http://msdn.microsoft.com/library/aa370890.aspx">PatchSourceList</html:a> for more information.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SymbolFlags" type="xs:int">
+        <xs:annotation>
+          <xs:documentation>An 8-digit hex integer representing the combination of patch symbol usage flags to use when creating a binary file patch. See <html:a href="http://msdn.microsoft.com/library/aa370890.aspx">ApiPatchingSymbolFlags</html:a> for more information.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="WholeFilesOnly" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Use this to set whether changing files should be included in their entirety. See <html:a href="http://msdn.microsoft.com/library/aa370890.aspx">IncludeWholeFilesOnly</html:a> for more information.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PatchInformation">
+    <xs:annotation>
+      <xs:documentation>Properties about the patch to be placed in the Summary Information Stream. These are visible from COM through the IStream interface, and these properties can be seen on the package in Explorer.</xs:documentation>
+      <xs:appinfo>
+        <xse:remarks>
+          <html:p>You can specify any valid Windows code by by integer like 1252, or by web name like Windows-1252. See [Code pages](../../tools/codepage.md) for more information.</html:p>
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Description" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>A short description of the patch that includes the name of the product.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Platforms" type="xs:string">
+        <xs:annotation>
+          <xs:appinfo>
+            <xse:deprecated />
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Languages" type="xs:string">
+        <xs:annotation>
+          <xs:appinfo>
+            <xse:deprecated />
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Manufacturer" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The name of the manufacturer of the patch package.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Keywords" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>A semicolon-delimited list of network or URL locations for alternate sources of the patch. The default is "Installer,Patching,PCP,Database".</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Comments" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>General purpose of the patch package. For example, "This patch contains the logic and data required to install _product_."</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ReadOnly" type="YesNoDefaultTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                        The value of this attribute conveys whether the package should be opened as read-only.
+                        A database editing tool should not modify a read-only enforced database and should
+                        issue a warning at attempts to modify a read-only recommended database.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SummaryCodepage" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The code page integer value or web name for summary info strings only. The default is 1252. See remarks for more information.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ShortNames" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:appinfo>
+            <xse:deprecated />
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Compressed" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:appinfo>
+            <xse:deprecated />
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="AdminImage" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:appinfo>
+            <xse:deprecated />
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PatchMetadata">
+    <xs:annotation>
+      <xs:documentation>Properties about the patch to be placed in the PatchMetadata table.</xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiPatchMetadata" href="http://msdn.microsoft.com/library/aa370344.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="CustomProperty" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>A custom property that extends the standard set.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element ref="OptimizeCustomActions" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Indicates whether custom actions can be skipped when applying the patch.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="AllowRemoval" type="YesNoTypeUnion" use="required">
+        <xs:annotation>
+          <xs:documentation>Whether this is an uninstallable patch.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Classification" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Category of updates. Recommended values are Critical Update, Hotfix, Security Rollup, Security Update, Service Pack, Update, Update Rollup.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="CreationTimeUTC" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Creation time of the .msp file in the form mm-dd-yy HH:MM (month-day-year hour:minute).</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Description" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Description of the patch.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DisplayName" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>A title for the patch that is suitable for public display. In Add/Remove Programs from XP SP2 on.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ManufacturerName" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Name of the manufacturer.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MinorUpdateTargetRTM" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    Indicates that the patch targets the RTM version of the product or the most recent major
+                    upgrade patch. Author this optional property in minor update patches that contain sequencing
+                    information to indicate that the patch removes all patches up to the RTM version of the
+                    product, or up to the most recent major upgrade patch. This property is available beginning
+                    with Windows Installer 3.1.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MoreInfoURL" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>A URL that provides information specific to this patch. In Add/Remove Programs from XP SP2 on.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OptimizedInstallMode" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    If this attribute is set to 'yes' in all the patches to be applied in a transaction, the
+                    application of the patch is optimized if possible. Available beginning with Windows Installer 3.1.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="TargetProductName" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Name of the application or target product suite.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CustomProperty">
+    <xs:annotation>
+      <xs:documentation>A custom property for the PatchMetadata table.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Company" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The name of the company.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Property" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The name of the metadata property.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Value of the metadata property.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ReplacePatch">
+    <xs:annotation>
+      <xs:documentation>A patch that is deprecated by this patch.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="Guid" use="required">
+        <xs:annotation>
+          <xs:documentation>Patch GUID to be unregistered if it exists on the machine targeted by this patch.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="TargetProductCodes">
+    <xs:annotation>
+      <xs:documentation>
+                The product codes for products that can accept the patch.
+            </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="TargetProductCode" />
+      </xs:choice>
+      <xs:attribute name="Replace" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Whether to replace the product codes that can accept the patch from the target packages with the child elements.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="TargetProductCode">
+    <xs:annotation>
+      <xs:documentation>
+                A product code for a product that can accept the patch.
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:remarks>
+          <html:p>When using the PatchCreation element, if the Id attribute value is '*' or this element is not authored, the product codes of all products referenced by the TargetImages element are used.</html:p>
+          <html:p>When using the Patch element, the Id attribute value must not be '*'. Use the TargetProductCodes/@Replace attribute instead.</html:p>
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+                        The product code for a product that can accept the patch. This can be '*'. See remarks for more information.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PatchProperty">
+    <xs:annotation>
+      <xs:documentation>A property for this patch database.</xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiPatchMetadata" href="http://msdn.microsoft.com/library/aa370344.aspx" />
+        <xse:remarks>
+          <html:p>When authored under the Patch element, the PatchProperty defines entries in the MsiPatchMetadata table.</html:p>
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Company" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Name of the company for a custom metadata property.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Name of the patch property.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Value of the patch property.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PatchSequence">
+    <xs:annotation>
+      <xs:documentation>Sequence information for this patch database. Sequence information is generated automatically in most cases, and rarely needs to be set explicitly.</xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiPatchSequence" href="http://msdn.microsoft.com/library/aa370350.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="PatchFamily" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier which indicates a sequence family to which this patch belongs.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProductCode" type="Guid">
+        <xs:annotation>
+          <xs:documentation>
+                        Specifies the ProductCode of the product that this family applies to.
+                        This attribute cannot the specified if the TargetImage attribute is specified.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Sequence" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Used to populate the sequence column of the MsiPatchSequence table in the final MSP file. Specified in x.x.x.x format. See documentation for Sequence column of MsiPatchSequence table in MSI SDK.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Supersede" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                        Set this value to 'yes' to indicate that this patch will supersede all previous patches in this patch family.
+                        The default value is 'no'.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Target" type="xs:string">
+        <xs:annotation>
+          <xs:appinfo>
+            <xse:deprecated ref="TargetImage" />
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="TargetImage" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                        Specifies the TargetImage that this family applies to.
+                        This attribute cannot the specified if the ProductCode attribute is specified.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Family">
+    <xs:annotation>
+      <xs:documentation>Group of one or more upgraded images of a product.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="UpgradeImage" maxOccurs="unbounded" />
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="ExternalFile" />
+          <xs:element ref="ProtectFile" />
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="DiskId" type="DiskIdType">
+        <xs:annotation>
+          <xs:documentation>Entered into the DiskId field of the new Media table record.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DiskPrompt" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Value to display in the "[1]" of the DiskPrompt Property. Using this attribute will require you to define a DiskPrompt Property.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MediaSrcProp" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Entered into the Source field of the new Media table entry of the upgraded image.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier for the family.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SequenceStart" type="xs:int">
+        <xs:annotation>
+          <xs:documentation>Sequence number for the starting file.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="VolumeLabel" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Entered into the VolumeLabel field of the new Media table record.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="UpgradeImage">
+    <xs:annotation>
+      <xs:documentation>Contains information about the upgraded images of the product.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="TargetImage" maxOccurs="unbounded" />
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="SymbolPath" />
+          <xs:element ref="UpgradeFile" />
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier to connect target images with upgraded image.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Full path to location of msi file for upgraded image.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourcePatch" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Modified copy of the upgraded installation database that contains additional authoring specific to patching.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="TargetImage">
+    <xs:annotation>
+      <xs:documentation>Contains information about the target images of the product.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="SymbolPath" />
+        <xs:element ref="TargetFile" />
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier for the target image.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Full path to the location of the msi file for the target image.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Order" type="xs:int" use="required">
+        <xs:annotation>
+          <xs:documentation>Relative order of the target image.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Validation" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Product checking to avoid applying irrelevant transforms.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreMissingFiles" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Files missing from the target image are ignored by the installer.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="TargetFile">
+    <xs:annotation>
+      <xs:documentation>Information about specific files in a target image.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="SymbolPath" minOccurs="0" />
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="IgnoreRange" />
+          <xs:element ref="ProtectRange" />
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Foreign key into the File table.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="IgnoreRange">
+    <xs:annotation>
+      <xs:documentation>Specifies part of a file that is to be ignored during patching.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Offset" type="xs:int" use="required">
+        <xs:annotation>
+          <xs:documentation>Offset of the start of the range.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Length" type="xs:int" use="required">
+        <xs:annotation>
+          <xs:documentation>Length of the range.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ProtectRange">
+    <xs:annotation>
+      <xs:documentation>Specifies part of a file that cannot be overwritten during patching.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Offset" type="xs:int" use="required">
+        <xs:annotation>
+          <xs:documentation>Offset of the start of the range.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Length" type="xs:int" use="required">
+        <xs:annotation>
+          <xs:documentation>Length of the range.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ProtectFile">
+    <xs:annotation>
+      <xs:documentation>Specifies a file to be protected.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="ProtectRange" />
+      </xs:choice>
+      <xs:attribute name="File" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Foreign key into the File table.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ExternalFile">
+    <xs:annotation>
+      <xs:documentation>Contains information about specific files that are not part of a regular target image.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="ProtectRange" maxOccurs="unbounded" />
+        <xs:element ref="SymbolPath" maxOccurs="unbounded" />
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="IgnoreRange" />
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="File" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Foreign key into the File table.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Source" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Full path of the external file.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Order" type="xs:int" use="required">
+        <xs:annotation>
+          <xs:documentation>Specifies the order of the external files to use when creating the patch.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="UpgradeFile">
+    <xs:annotation>
+      <xs:documentation>Specifies files to either ignore or to specify optional data about a file.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="SymbolPath" />
+      </xs:choice>
+      <xs:attribute name="File" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Foreign key into the File table.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Ignore" type="YesNoTypeUnion" use="required">
+        <xs:annotation>
+          <xs:documentation>If yes, the file is ignored during patching, and the next two attributes are ignored.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="AllowIgnoreOnError" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Specifies whether patching this file is vital.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="WholeFile" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Whether the whole file should be installed, rather than creating a binary patch.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SymbolPath">
+    <xs:annotation>
+      <xs:documentation>A path to symbols.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Path" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The path.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SummaryInformation">
+    <xs:annotation>
+      <xs:documentation>
+        Properties about the package to be placed in the Summary Information Stream. These are
+        visible from COM through the IStream interface, and these properties can be seen on the package in Explorer.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:remarks>
+          <html:p>You can specify any valid Windows code by by integer like 1252, or by web name like Windows-1252. See [Code pages](../../tools/codepage.md) for more information.</html:p>
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Codepage" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The code page integer value or web name for summary info strings only. See remarks for more information.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Description" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The product full name or description.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Keywords" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Optional keywords for browsing.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Manufacturer" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The vendor releasing the package. Defaults to the Package/@Manufacturer attribute's value.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AssemblyName">
+    <xs:annotation>
+      <xs:documentation>
+                The MsiAssemblyName table specifies the schema for the elements of a strong assembly cache name for a .NET Framework or Win32 assembly.
+                Consider using the Assembly attribute on File element to have the toolset populate these entries automatically.
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiAssemblyName" href="http://msdn.microsoft.com/library/aa370062.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Name of the attribute associated with the value specified in the Value column.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Value associated with the name specified in the Name column.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PatchCertificates">
+    <xs:annotation>
+      <xs:documentation>
+                Identifies the possible signer certificates used to digitally sign patches.
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiPatchCertificate" href="http://msdn.microsoft.com/library/aa370342.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="DigitalCertificate" />
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PackageCertificates">
+    <xs:annotation>
+      <xs:documentation>
+          Digital signatures that identify installation packages in a multi-product transaction.
+        </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiPackageCertificate" href="http://msdn.microsoft.com/library/cc542575.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="DigitalCertificate" />
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="DigitalCertificate">
+    <xs:annotation>
+      <xs:documentation>
+                Adds a digital certificate.
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiDigitalCertificate" href="http://msdn.microsoft.com/library/aa370086.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier for a certificate file.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceFile" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The path to the certificate file.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="DigitalCertificateRef">
+    <xs:annotation>
+      <xs:documentation>
+        Reference to a DigitalCertificate element. This will force the entire referenced Fragment's contents
+        to be included in the installer database. This is only used for references when patching.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required" />
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="DigitalSignature">
+    <xs:annotation>
+      <xs:documentation>
+                Adds a digital signature.
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiDigitalSignature" href="http://msdn.microsoft.com/library/aa370087.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="DigitalCertificate" />
+      </xs:choice>
+      <xs:attribute name="SourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The path to signature's optional hash file.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SFPCatalog">
+    <xs:annotation>
+      <xs:documentation>
+                Adds a system file protection update catalog file
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="SFPCatalog" href="http://msdn.microsoft.com/library/aa371833.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="SFPCatalog" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element ref="SFPFile" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Primary Key to File Table.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="Name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Filename for catalog file when installed.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Dependency" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Used to define dependency outside of the package.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Path to catalog file in binary.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SFPFile">
+    <xs:annotation>
+      <xs:documentation>
+        Provides a many-to-many mapping from the SFPCatalog table to the File table
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="FileSFPCatalog" href="http://msdn.microsoft.com/library/aa368591.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Primary Key to File Table.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="IniFile">
+    <xs:annotation>
+      <xs:documentation>
+        Adds or removes .ini file entries.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="IniFile" href="https://learn.microsoft.com/en-us/windows/win32/msi/inifile-table" />
+        <xse:msiRef table="RemoveIniFile" href="https://learn.microsoft.com/en-us/windows/win32/msi/removeinifile-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Identifier for ini file. If one is not specified a stable identifier will be generated.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Action" use="required">
+        <xs:annotation>
+          <xs:documentation>The type of modification to be made.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="addLine">
+              <xs:annotation>
+                <xs:documentation>Creates or updates an .ini entry.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="addTag">
+              <xs:annotation>
+                <xs:documentation>Creates a new entry or appends a new comma-separated value to an existing entry.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="createLine">
+              <xs:annotation>
+                <xs:documentation>Creates an .ini entry only if the entry does no already exist.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="removeLine">
+              <xs:annotation>
+                <xs:documentation>Removes an .ini entry.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="removeTag">
+              <xs:annotation>
+                <xs:documentation>Removes a tag from an .ini entry.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Directory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Name of a property, the value of which is the full path of the folder containing the .ini file. Can be name of a directory in the Directory table, a property set by the AppSearch table, or any other property representing a full path.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Key" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The localizable .ini file key within the section.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="LongFileNameType" use="required">
+        <xs:annotation>
+          <xs:documentation>
+                        In prior versions of the WiX toolset, this attribute specified the short name.
+                        This attribute's value may now be either a short or long name.
+                        If a short name is specified, the ShortName attribute may not be specified.
+                        Also, if this value is a long name, the ShortName attribute may be omitted to
+                        allow WiX to attempt to generate a unique short name.
+                        However, if this name collides with another file or you wish to manually specify
+                        the short name, then the ShortName attribute may be specified.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Section" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The localizable .ini file section.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ShortName" type="ShortFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+                        The short name of the in 8.3 format.
+                        This attribute should only be set if there is a conflict between generated short names
+                        or the user wants to manually specify the short name.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                        The localizable value to be written or deleted. This attribute must be set if
+                        the Action attribute's value is "addLine", "addTag", or "createLine".
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ODBCDataSource">
+    <xs:annotation>
+      <xs:documentation>
+                ODBCDataSource for a Component
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="ODBCDataSource" href="http://msdn.microsoft.com/library/aa370546.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Property">
+          <xs:annotation>
+            <xs:documentation>Translates into ODBCSourceAttributes</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="Id" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Identifier of the data source.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Name for the data source.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DriverName" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Required if not found as child of ODBCDriver element</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Registration" use="required">
+        <xs:annotation>
+          <xs:documentation>Scope for which the data source should be registered.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="machine">
+              <xs:annotation>
+                <xs:documentation>
+                                    Data source is registered per machine.
+                                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="user">
+              <xs:annotation>
+                <xs:documentation>
+                                    Data source is registered per user.
+                                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="KeyPath" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set 'yes' to force this file to be key path for parent Component</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ODBCDriver">
+    <xs:annotation>
+      <xs:documentation>
+                ODBCDriver for a Component
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="ODBCDriver" href="http://msdn.microsoft.com/library/aa370547.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Property">
+          <xs:annotation>
+            <xs:documentation>Translates into ODBCSourceAttributes</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ODBCDataSource" />
+      </xs:choice>
+      <xs:attribute name="Id" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Identifier for the driver.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Name for the driver.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="File" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Required if not found as child of File element</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SetupFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Required if not found as child of File element or different from File attribute above</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ODBCTranslator">
+    <xs:annotation>
+      <xs:documentation>
+                ODBCTranslator for a Component
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="ODBCTranslator" href="http://msdn.microsoft.com/library/aa370549.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Identifier for the translator.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Name for the translator.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="File" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Required if not found as child of File element</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SetupFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Required if not found as child of File element or different from File attribute above</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="FileSearch">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="ComponentSearch" />
+        <xse:seeAlso ref="DirectorySearch" />
+        <xse:seeAlso ref="DirectorySearchRef" />
+        <xse:seeAlso ref="FileSearchRef" />
+        <xse:seeAlso ref="IniFileSearch" />
+        <xse:seeAlso ref="RegistrySearch" />
+        <xse:msiRef table="DrLocator" href="http://msdn.microsoft.com/library/aa368331.aspx" />
+        <xse:msiRef table="Signature" href="https://docs.microsoft.com/en-us/windows/win32/msi/signature-table" />
+        <xse:howtoRef href="files_and_registry/check_the_version_number.html">How To: Check the version number of a file during installation</xse:howtoRef>
+        <xse:remarks>
+          When the parent DirectorySearch/@Depth attribute is greater than 0, the FileSearch/@Id attribute must be absent or the same as the parent DirectorySearch/@Id attribute value, unless the parent DirectorySearch/@AssignToProperty attribute value is 'yes'.
+        </xse:remarks>
+      </xs:appinfo>
+      <xs:documentation>Searches for file and assigns to fullpath value of parent Property</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Unique identifier for the file search and external key into the Signature table. If this attribute value is not set then the parent element's @Id attribute is used.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="LongFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+                        In prior versions of the WiX toolset, this attribute specified the short file name.
+                        This attribute's value may now be either a short or long file name.
+                        If a short file name is specified, the ShortName attribute may not be specified.
+                        If you wish to manually specify the short file name, then the ShortName
+                        attribute may be specified.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ShortName" type="ShortFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+                        The short file name of the file in 8.3 format.
+                        There is a Windows Installer bug which prevents the FileSearch functionality from working
+                        if both a short and long file name are specified. Since the Name attribute allows either
+                        a short or long name to be specified, it is the only attribute related to file names which
+                        should be specified.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MinSize" type="xs:int">
+        <xs:annotation>
+          <xs:documentation>The minimum size of the file.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MaxSize" type="xs:int">
+        <xs:annotation>
+          <xs:documentation>The maximum size of the file.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MinVersion" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The minimum version of the file.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MaxVersion" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The maximum version of the file.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MinDate" type="xs:dateTime">
+        <xs:annotation>
+          <xs:documentation>The minimum modification date and time of the file. Formatted as YYYY-MM-DDTHH:mm:ss, where YYYY is the year, MM is month, DD is day, 'T' is literal, HH is hour, mm is minute and ss is second.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MaxDate" type="xs:dateTime">
+        <xs:annotation>
+          <xs:documentation>The maximum modification date and time of the file. Formatted as YYYY-MM-DDTHH:mm:ss, where YYYY is the year, MM is month, DD is day, 'T' is literal, HH is hour, mm is minute and ss is second.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Languages" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The languages supported by the file.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="FileSearchRef">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="FileSearch" />
+        <xse:remarks>
+          <html:p>A reference to another FileSearch element must reference the same Id and the same Parent Id. If any of these attribute values are different you must instead use a FileSearch element.</html:p>
+        </xse:remarks>
+      </xs:appinfo>
+      <xs:documentation>References an existing FileSearch element.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Specify the Id to the FileSearch to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="DirectorySearch">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="ComponentSearch" />
+        <xse:seeAlso ref="IniFileSearch" />
+        <xse:seeAlso ref="RegistrySearch" />
+        <xse:msiRef table="DrLocator" href="http://msdn.microsoft.com/library/aa368331.aspx" />
+        <xse:msiRef table="Signature" href="https://docs.microsoft.com/en-us/windows/win32/msi/signature-table" />
+        <xse:howtoRef href="files_and_registry/check_the_version_number.html">How To: Check the version number of a file during installation</xse:howtoRef>
+        <xse:howtoRef href="files_and_registry/directorysearchref.html">How To: Reference another DirectorySearch element</xse:howtoRef>
+        <xse:howtoRef href="files_and_registry/parentdirectorysearch.html">How To: Get the parent directory of a file search</xse:howtoRef>
+        <xse:remarks>
+          Use the AssignToProperty attribute to search for a file but set the outer property to the directory containing the file. When this attribute is set to 'yes', you may only nest a FileSearch element with a unique Id or define no child element.
+          When the parent DirectorySearch/@Depth attribute is greater than 0, the FileSearch/@Id attribute must be absent or the same as the parent DirectorySearch/@Id attribute value, unless the parent DirectorySearch/@AssignToProperty attribute value is 'yes'.
+        </xse:remarks>
+      </xs:appinfo>
+      <xs:documentation>Searches for directory and assigns to value of parent Property.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:element ref="DirectorySearch" />
+        <xs:element ref="DirectorySearchRef" />
+        <xs:element ref="FileSearch" />
+        <xs:element ref="FileSearchRef" />
+      </xs:choice>
+      <xs:attribute name="Id" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Unique identifier for the directory search.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Path" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Path on the user's system. Either absolute, or relative to containing directories.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Depth" type="Integer">
+        <xs:annotation>
+          <xs:documentation>
+                        Depth below the path that the installer searches for the file or directory specified by the search. See remarks for more information.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="AssignToProperty" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set the value of the outer Property to the result of this search. See remarks for more information.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="DirectorySearchRef">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="ComponentSearch" />
+        <xse:seeAlso ref="IniFileSearch" />
+        <xse:seeAlso ref="RegistrySearch" />
+        <xse:howtoRef href="files_and_registry/directorysearchref.html">How To: Reference another DirectorySearch element</xse:howtoRef>
+        <xse:remarks>
+          <html:p>A reference to another DirectorySearch element must reference the same Id, the same Parent Id, and the same Path. If any of these attribute values are different you must instead use a DirectorySearch element.</html:p>
+        </xse:remarks>
+      </xs:appinfo>
+      <xs:documentation>References an existing DirectorySearch element.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:element ref="DirectorySearch" />
+        <xs:element ref="DirectorySearchRef" />
+        <xs:element ref="FileSearch" />
+        <xs:element ref="FileSearchRef" />
+      </xs:choice>
+      <xs:attribute name="Id" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Id of the search being referred to.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Parent" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>This attribute is the signature of the parent directory of the file or directory in the Signature_ column. If this field is null, and the Path column does not expand to a full path, then all the fixed drives of the user's system are searched by using the Path. This field is a key into one of the following tables: the RegLocator, the IniLocator, the CompLocator, or the DrLocator tables.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Path" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Path on the user's system. Either absolute, or relative to containing directories.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ComponentSearch">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="IniFileSearch" />
+        <xse:seeAlso ref="RegistrySearch" />
+        <xse:msiRef table="CompLocator" href="http://msdn.microsoft.com/library/aa368001.aspx" />
+        <xse:msiRef table="Signature" href="https://docs.microsoft.com/en-us/windows/win32/msi/signature-table" />
+      </xs:appinfo>
+      <xs:documentation>Searches for file or directory and assigns to value of parent Property.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:element ref="DirectorySearch" />
+        <xs:element ref="DirectorySearchRef" />
+        <xs:element ref="FileSearch" />
+        <xs:element ref="FileSearchRef" />
+      </xs:choice>
+      <xs:attribute name="Id" use="required" type="xs:string" />
+      <xs:attribute name="Guid" type="Guid">
+        <xs:annotation>
+          <xs:documentation>The component ID of the component whose key path is to be used for the search.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Type">
+        <xs:annotation>
+          <xs:documentation>Must be file if last child is FileSearch element and must be directory if last child is DirectorySearch element.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="directory">
+              <xs:annotation>
+                <xs:documentation>
+                                    The key path of the component is a directory.
+                                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="file">
+              <xs:annotation>
+                <xs:documentation>
+                                    The key path of the component is a file. This is the default value.
+                                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="IniFileSearch">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="ComponentSearch" />
+        <xse:seeAlso ref="RegistrySearch" />
+        <xse:msiRef table="IniLocator" href="http://msdn.microsoft.com/library/aa369283.aspx" />
+        <xse:msiRef table="Signature" href="https://docs.microsoft.com/en-us/windows/win32/msi/signature-table" />
+      </xs:appinfo>
+      <xs:documentation>Searches for file, directory or registry key and assigns to value of parent Property</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:element ref="DirectorySearch" />
+        <xs:element ref="DirectorySearchRef" />
+        <xs:element ref="FileSearch" />
+        <xs:element ref="FileSearchRef" />
+      </xs:choice>
+      <xs:attribute name="Id" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>External key into the Signature table.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Field" type="Integer">
+        <xs:annotation>
+          <xs:documentation>The field in the .ini line. If field is Null or 0, the entire line is read.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Key" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The key value within the section.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="LongFileNameType" use="required">
+        <xs:annotation>
+          <xs:documentation>
+                        In prior versions of the WiX toolset, this attribute specified the short name.
+                        This attribute's value may now be either a short or long name.
+                        If a short name is specified, the ShortName attribute may not be specified.
+                        Also, if this value is a long name, the ShortName attribute may be omitted to
+                        allow WiX to attempt to generate a unique short name.
+                        However, if you wish to manually specify the short name, then the ShortName
+                        attribute may be specified.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Section" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The localizable .ini file section.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ShortName" type="ShortFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+                        The short name of the file in 8.3 format.
+                        This attribute should only be set if the user wants to manually specify the short name.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Type">
+        <xs:annotation>
+          <xs:documentation>Must be file if last child is FileSearch element and must be directory if last child is DirectorySearch element.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="directory">
+              <xs:annotation>
+                <xs:documentation>A directory location.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="file">
+              <xs:annotation>
+                <xs:documentation>A file location. This is the default value.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="raw">
+              <xs:annotation>
+                <xs:documentation>A raw .ini value.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RegistrySearch">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="ComponentSearch" />
+        <xse:seeAlso ref="IniFileSearch" />
+        <xse:msiRef table="RegLocator" href="http://msdn.microsoft.com/library/aa371171.aspx" />
+        <xse:msiRef table="Signature" href="https://docs.microsoft.com/en-us/windows/win32/msi/signature-table" />
+        <xse:howtoRef href="files_and_registry/read_a_registry_entry.html">How To: Read a registry entry during installation</xse:howtoRef>
+        <xse:remarks>
+          <html:p>
+                        When the Type attribute value is 'directory' the registry value must specify the path to a directory excluding the file name.
+                        When the Type attribute value is 'file' the registry value must specify the path to a file including the file name;
+                        however, if there is no child FileSearch element the parent directory of the file is returned. The FileSearch element requires
+                        that you author the name of the file you are searching for. If you do not know the file name
+                        you must set the Type attribute to 'raw' to return the full file path including the file name.
+                    </html:p>
+        </xse:remarks>
+      </xs:appinfo>
+      <xs:documentation>Searches for file, directory or registry key and assigns to value of parent Property</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:element ref="DirectorySearch" />
+        <xs:element ref="DirectorySearchRef" />
+        <xs:element ref="FileSearch" />
+        <xs:element ref="FileSearchRef" />
+      </xs:choice>
+      <xs:attribute name="Id" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Signature to be used for the file, directory or registry key being searched for.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Bitness" type="BitnessTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Overrides the default registry to search. The value `always64` will force
+            the search to look in the 64-bit registry even when building for 32-bit.
+            Simliarly, the value `always32` will force the search to look in the 32-bit
+            registry even when building for 64-bit.
+            The default value is `default` where the search will look in the same registry
+            as the bitness of the package.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Root" use="required">
+        <xs:annotation>
+          <xs:documentation>Root key for the registry value.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="HKCR">
+              <xs:annotation>
+                <xs:documentation>
+                                    HKEY_CLASSES_ROOT
+                                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HKCU">
+              <xs:annotation>
+                <xs:documentation>
+                                    HKEY_CURRENT_USER
+                                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HKLM">
+              <xs:annotation>
+                <xs:documentation>
+                                    HKEY_LOCAL_MACHINE
+                                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="HKU">
+              <xs:annotation>
+                <xs:documentation>
+                                    HKEY_USERS
+                                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Key" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Key for the registry value.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Registry value name. If this value is null, then the value from the key's unnamed or default value, if any, is retrieved.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Type" use="required">
+        <xs:annotation>
+          <xs:documentation>
+                        The value must be 'file' if the child is a FileSearch element, and must be 'directory' if child is a DirectorySearch element.
+                    </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="directory">
+              <xs:annotation>
+                <xs:documentation>
+                    The registry value contains the path to a directory.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="file">
+              <xs:annotation>
+                <xs:documentation>
+                    The registry value contains the path to a file. To return the full file path you must add a FileSearch element as a child of this element; otherwise, the parent directory of the file path is returned.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="raw">
+              <xs:annotation>
+                <xs:documentation>
+                    Sets the raw value from the registry value. Please note that this value will contain a prefix as follows:
+
+                    - DWORD: Starts with `#` optionally followed by `+` or `-`.
+                    - REG_BINARY: Starts with `#x` and the installer converts and saves each hexadecimal digit (nibble) as an ASCII character prefixed by `#x`.
+                    - REG_EXPAND_SZ: Starts with `#%`.
+                    - REG_MULTI_SZ: Starts with `[~]` and ends with `[~]`.
+                    - REG_SZ: No prefix, but if the first character of the registry value is `#`, the installer escapes the character by prefixing it with another `#`.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RegistrySearchRef">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="RegistrySearch" />
+      </xs:appinfo>
+      <xs:documentation>References an existing RegistrySearch element.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Specify the Id of the RegistrySearch to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ComplianceDrive">
+    <xs:annotation>
+      <xs:documentation>Sets the parent of a nested DirectorySearch element to CCP_DRIVE.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice>
+        <xs:element ref="DirectorySearch" />
+        <xs:element ref="DirectorySearchRef" />
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ComplianceCheck">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Property" />
+        <xse:msiRef table="CCPSearch" href="https://docs.microsoft.com/en-us/windows/win32/msi/ccpsearch-table" />
+        <xse:msiRef table="Signature" href="https://docs.microsoft.com/en-us/windows/win32/msi/signature-table" />
+      </xs:appinfo>
+      <xs:documentation>Adds a row to the CCPSearch table.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:sequence>
+          <xs:element ref="ComplianceDrive" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Starts searches from the CCP_DRIVE.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element ref="ComponentSearch" minOccurs="0" maxOccurs="unbounded" />
+          <xs:element ref="RegistrySearch" minOccurs="0" maxOccurs="unbounded" />
+          <xs:element ref="IniFileSearch" minOccurs="0" maxOccurs="unbounded" />
+          <xs:element ref="DirectorySearch" minOccurs="0" maxOccurs="unbounded" />
+          <xs:any namespace="##other" processContents="lax">
+            <xs:annotation>
+              <xs:documentation>
+                Extensibility point in the WiX XML Schema. Schema extensions can register additional
+                elements at this point in the schema.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:any>
+        </xs:sequence>
+      </xs:choice>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Property">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="PropertyRef" />
+        <xse:msiRef table="Property" href="http://msdn.microsoft.com/library/aa370908.aspx" />
+        <xse:howtoRef href="files_and_registry/check_the_version_number.html">How To: Check the version number of a file during installation</xse:howtoRef>
+      </xs:appinfo>
+      <xs:documentation>Property value for a Package or Module.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="ComplianceDrive" />
+        <xs:element ref="ComponentSearch"/>
+        <xs:element ref="RegistrySearch"/>
+        <xs:element ref="RegistrySearchRef"/>
+        <xs:element ref="IniFileSearch"/>
+        <xs:element ref="DirectorySearch"/>
+        <xs:element ref="DirectorySearchRef"/>
+        <xs:element ref="ProductSearch"/>
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Unique identifier for Property.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Sets a default value for the property. The value will be overwritten if the Property is used for a search.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ComplianceCheck" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Adds a row to the CCPSearch table. This attribute is only valid when this Property contains a search element.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Admin" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Denotes that the property is saved during [administrative installations](https://learn.microsoft.com/en-us/windows/win32/msi/administrative-installation).
+            Adds the property name to the [AdminProperties property](https://learn.microsoft.com/en-us/windows/win32/msi/adminproperties).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Secure" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Denotes that the Property can be passed to the server side when doing a managed installation with elevated privileges. See the <html:a href="https://learn.microsoft.com/en-us/windows/win32/msi/securecustomproperties">SecureCustomProperties Property</html:a> for more information.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Hidden" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Denotes that the Property is not logged during installation. See the <html:a href="https://learn.microsoft.com/en-us/windows/win32/msi/msihiddenproperties">MsiHiddenProperties Property</html:a> for more information.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SuppressModularization" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Use to suppress modularization of this property identifier in merge modules.
+            Using this functionality is strongly discouraged; it should only be
+            necessary as a workaround of last resort in rare scenarios.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PropertyRef">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Property" />
+        <xse:howtoRef href="redistributables_and_install_checks/check_for_dotnet.html">How To: Check for .NET Framework versions</xse:howtoRef>
+      </xs:appinfo>
+      <xs:documentation>Reference to a Property value.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier of Property to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SoftwareTagRef">
+    <xs:annotation>
+      <xs:documentation>Reference to a SoftwareTag by Regid.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Regid" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Regid of SoftwareTag to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Shortcut">
+    <xs:annotation>
+      <xs:documentation>
+        Shortcut, default target is parent File, CreateFolder, or Component's Directory
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Shortcut" href="http://msdn.microsoft.com/library/aa371847.aspx" />
+        <xse:howtoRef href="files_and_registry/create_start_menu_shortcut.html">How To: Create a shortcut on the Start Menu</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Icon" minOccurs="0" />
+        <xs:element ref="ShortcutProperty" minOccurs="0" />
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Unique identifier for the shortcut. This value will serve as the primary key for the row.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Directory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Identifier reference to Directory element where shortcut is to be created. When nested under a Component element, this attribute's value will default to the parent directory. Otherwise, this attribute is required.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="LongFileNameType" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            If a short name is specified, the ShortName attribute may not be specified.
+            If this value is a long name, the ShortName attribute may be omitted to
+            allow WiX to attempt to generate a unique short name.
+            However, if this name collides with another shortcut or you wish to manually specify
+            the short name, then the ShortName attribute may be specified.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ShortName" type="ShortFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+            The short name of the shortcut in 8.3 format.
+            This attribute should only be set if there is a conflict between generated short names
+            or the user wants to manually specify the short name.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Target" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute can only be set if this Shortcut element is nested under a Component element.
+            When nested under a Component element, this attribute's value will default to the parent directory.
+            This attribute's value is the target for a non-advertised shortcut.
+            This attribute is not valid for advertised shortcuts.
+            If you specify this value, its value should be a property identifier enclosed by square brackets ([ ]), that is expanded into the file or a folder pointed to by the shortcut.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Description" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The localizable description for the shortcut.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Arguments" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The command-line arguments for the shortcut. Note that the resolution of properties
+              in the Arguments field is limited. A property formatted as [Property] in this field can only be resolved if the
+              property already has the intended value when the component owning the shortcut is installed. For example, for the
+              argument "[#MyDoc.doc]" to resolve to the correct value, the same process must be installing the file MyDoc.doc and
+              the component that owns the shortcut.
+            </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Hotkey" type="Integer">
+        <xs:annotation>
+          <xs:documentation>
+            The hotkey for the shortcut. The low-order byte contains the virtual-key code for
+              the key, and the high-order byte contains modifier flags. This must be a non-negative number. Authors of
+              installation packages are generally recommend not to set this option, because this can add duplicate hotkeys to a
+              users desktop. In addition, the practice of assigning hotkeys to shortcuts can be problematic for users using hotkeys
+              for accessibility.
+            </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Icon" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Identifier reference to Icon element. The Icon identifier should have the same extension
+            as the file that it points at. For example, a shortcut to an executable (e.g. "my.exe") should reference an Icon with identifier
+            like "MyIcon.exe"
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IconIndex" type="Integer">
+        <xs:annotation>
+          <xs:documentation>Identifier reference to Icon element.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Show">
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="normal">
+              <xs:annotation>
+                <xs:documentation>
+                  The shortcut target will be displayed using the SW_SHOWNORMAL attribute.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="minimized">
+              <xs:annotation>
+                <xs:documentation>
+                  The shortcut target will be displayed using the SW_SHOWMINNOACTIVE attribute.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="maximized">
+              <xs:annotation>
+                <xs:documentation>
+                  The shortcut target will be displayed using the SW_SHOWMAXIMIZED attribute.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Subdirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute defines one or more directories below the directory referenced by the Directory attribute
+            where the shortcut will be installed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="WorkingDirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Directory identifier (or Property identifier that resolves to a directory) that resolves
+            to the path of the working directory for the shortcut.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="WorkingSubdirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute defines one or more directories below the directory referenced by the WorkingDirectory attribute
+            for the shortcut's working directory.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Advertise" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies if the shortcut should be advertised or not. Note that advertised shortcuts
+            always point at a particular application, identified by a ProductCode, and should not be shared between applications.
+            Advertised shortcuts only work for the most recently installed application, and are removed when that application is
+            removed. The default value is 'no'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DisplayResourceDll" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The Formatted string providing the full path to the language neutral file containing the MUI Manifest. Generally
+            authored using [#filekey] form. When this attribute is specified, the DisplayResourceId attribute must also
+            be provided.
+
+            This attribute is only used on Windows Vista and above. If this attribute is not populated and the install
+            is running on Vista and above, the value in the Name attribute is used. If this attribute is populated and
+            the install is running on Vista and above, the value in the Name attribute is ignored.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DisplayResourceId" type="Integer">
+        <xs:annotation>
+          <xs:documentation>
+            The display name index for the shortcut. This must be a non-negative number. When this attribute is specified, the
+            DisplayResourceDll attribute must also be provided.
+
+            This attribute is only used on Windows Vista and above. If this attribute is not specified and the install
+            is running on Vista and above, the value in the Name attribute is used. If this attribute is specified and
+            the install is running on Vista and above, the value in the Name attribute is ignored.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DescriptionResourceDll" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The Formatted string providing the full path to the language neutral file containing the MUI Manifest. Generally
+            authored using [#filekey] form. When this attribute is specified, the DescriptionResourceId attribute must also
+            be provided.
+
+            This attribute is only used on Windows Vista and above. If this attribute is not specified and the install
+            is running on Vista and above, the value in the Name attribute is used. If this attribute is provided and
+            the install is running on Vista and above, the value in the Name attribute is ignored.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DescriptionResourceId" type="Integer">
+        <xs:annotation>
+          <xs:documentation>
+            The description name index for the shortcut. This must be a non-negative number. When this attribute is specified,
+            the DescriptionResourceDll attribute must also be populated.
+
+            This attribute is only used on Windows Vista and above. If this attribute is not specified and the install
+            is running on Vista and above, the value in the Name attribute is used. If this attribute is populated and the
+            install is running on Vista and above, the value in the Name attribute is ignored.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ShortcutProperty">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Shortcut" />
+        <xse:msiRef table="MsiShortcutProperty" />
+      </xs:appinfo>
+      <xs:documentation>Property values for a shortcut. This element's functionality is available starting with MSI 5.0.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Unique identifier for MsiShortcutProperty table. If omitted, a stable identifier will be generated from the parent shortcut identifier and Key value.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Key" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>A formatted string identifying the property to be set.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>A formatted string supplying the value of the property.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Permission">
+    <xs:annotation>
+      <xs:documentation>
+                Sets ACLs on File, Registry, or CreateFolder. When under a Registry element, this cannot be used
+                if the Action attribute's value is remove or removeKeyOnInstall. This element has no Id attribute.
+                The table and key are taken from the parent element.
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="LockPermissions" href="http://msdn.microsoft.com/library/aa369774.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Domain" type="xs:string"></xs:attribute>
+      <xs:attribute name="User" use="required" type="xs:string"></xs:attribute>
+      <!-- Common ACLs -->
+      <xs:attribute name="Read" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="Delete" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="ReadPermission" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="ChangePermission" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="TakeOwnership" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="SpecificRightsAll" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Bit mask for SPECIFIC_RIGHTS_ALL from WinNT.h (0x0000FFFF).</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <!-- Folder and File ACLs -->
+      <xs:attribute name="ReadAttributes" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="WriteAttributes" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="ReadExtendedAttributes" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="WriteExtendedAttributes" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="Synchronize" type="YesNoTypeUnion"></xs:attribute>
+      <!-- Folder only ACLs -->
+      <xs:attribute name="CreateFile" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>For a directory, the right to create a file in the directory. Only valid under a 'CreateFolder' parent.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="CreateChild" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>For a directory, the right to create a subdirectory. Only valid under a 'CreateFolder' parent.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DeleteChild" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>For a directory, the right to delete a directory and all the files it contains, including read-only files. Only valid under a 'CreateFolder' parent.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Traverse" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>For a directory, the right to traverse the directory. By default, users are assigned the BYPASS_TRAVERSE_CHECKING privilege, which ignores the FILE_TRAVERSE access right. Only valid under a 'CreateFolder' parent.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <!-- File only ACLs -->
+      <xs:attribute name="Append" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="Execute" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="FileAllRights" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Bit mask for FILE_ALL_ACCESS from WinNT.h (0x001F01FF).</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <!-- File and Registry ACLs -->
+      <xs:attribute name="Write" type="YesNoTypeUnion"></xs:attribute>
+      <!-- Registry only ACLs -->
+      <xs:attribute name="CreateSubkeys" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="EnumerateSubkeys" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="Notify" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="CreateLink" type="YesNoTypeUnion"></xs:attribute>
+      <!-- Generic ACLs, mapped by system to appropriate permissions -->
+      <xs:attribute name="GenericAll" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="GenericExecute" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="GenericWrite" type="YesNoTypeUnion"></xs:attribute>
+      <xs:attribute name="GenericRead" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>specifying this will fail to grant read access</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PermissionEx">
+    <xs:annotation>
+      <xs:documentation>
+                Sets ACLs on File, Registry, or CreateFolder. When under a Registry element, this cannot be used
+                if the Action attribute's value is remove or removeKeyOnInstall. This element is only available
+                when installing with MSI 5.0. For downlevel support, see the PermissionEx element from the
+                WixUtilExtension.
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiLockPermissionsEx" href="http://msdn.microsoft.com/library/aa369774.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    Primary key used to identify this particular entry. If this is not specified the parent element's Id attribute
+                    will be used instead.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Condition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Optional condition that controls whether the permissions are applied.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Sddl" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+                    Security descriptor to apply to parent object.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CopyFile">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="RemoveFile" />
+        <xse:msiRef table="DuplicateFile" href="http://msdn.microsoft.com/library/aa368335.aspx" />
+        <xse:msiRef table="MoveFile" href="http://msdn.microsoft.com/library/aa370055.aspx" />
+      </xs:appinfo>
+      <xs:documentation>
+                Copy or move an existing file on the target machine, or copy a file that is being installed, to another destination. When
+                this element is nested under a File element, the parent file will be installed, then copied to the specified destination
+                if the parent component of the file is selected for installation or removal. When this element is nested under
+                a Component element and no FileId attribute is specified, the file to copy or move must already be on the target machine.
+                When this element is nested under a Component element and the FileId attribute is specified, the specified file is installed,
+                then copied to the specified destination if the parent component is selected for installation or removal (use
+                this option to control the copy of a file in a different component by the parent component's installation state). If the
+                specified destination directory is the same as the directory containing the original file and the name for the proposed source
+                file is the same as the original, then no action takes place.
+            </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Primary key used to identify this particular entry.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="FileId" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    This attribute cannot be specified if the element is nested under a File element. Set this attribute's value to the identifier
+                    of a file from a different component to copy it based on the install state of the parent component.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceDirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    This attribute cannot be specified if the element is nested under a File element or the FileId attribute is specified. Set
+                    this value to the source directory from which to copy or move an existing file on the target machine. This Directory must
+                    exist in the installer database at creation time. This attribute cannot be specified in conjunction with SourceProperty.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceProperty" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    This attribute cannot be specified if the element is nested under a File element or the FileId attribute is specified. Set
+                    this value to a property that will have a value that resolves to the full path of the source directory (or full path
+                    including file name if SourceName is not specified). The property does not have to exist in the installer database at
+                    creation time; it could be created at installation time by a custom action, on the command line, etc. This attribute
+                    cannot be specified in conjunction with SourceDirectory.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceName" type="WildCardLongFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+                    This attribute cannot be specified if the element is nested under a File element or the FileId attribute is specified. Set
+                    this value to the localizable name of the file(s) to be copied or moved. All of the files that
+                    match the wild card will be removed from the specified directory. The value is a filename that may also
+                    contain the wild card characters "?" for any single character or "*" for zero or more occurrences of any character. If this
+                    attribute is not specified (and this element is not nested under a File element or specify a FileId attribute) then the
+                    SourceProperty attribute should be set to the name of a property that will resolve to the full path of the source filename.
+                    If the value of this attribute contains a "*" wildcard and the DestinationName attribute is specified, all moved or copied
+                    files retain the file names from their sources.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DestinationDirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    Set this value to the destination directory where an existing file on the target machine should be moved or copied to. This
+                    Directory must exist in the installer database at creation time. This attribute cannot be specified in conjunction with
+                    DestinationProperty.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DestinationProperty" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    Set this value to a property that will have a value that resolves to the full path of the destination directory. The property
+                    does not have to exist in the installer database at creation time; it could be created at installation time by a custom
+                    action, on the command line, etc. This attribute cannot be specified in conjunction with DestinationDirectory.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DestinationName" type="LongFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+                  In prior versions of the WiX toolset, this attribute specified the short file name.
+                  Now set this value to the localizable name to be given to the original file after it is moved or copied.
+                  If this attribute is not specified, then the destination file is given the same name as the source file.
+                  If a short file name is specified, the DestinationShortName attribute may not be specified.
+                  Also, if this value is a long file name, the DestinationShortName attribute may be omitted to
+                  allow WiX to attempt to generate a unique short file name.
+                  However, if this name collides with another file or you wish to manually specify
+                  the short file name, then the DestinationShortName attribute may be specified.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DestinationShortName" type="ShortFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+                  The short file name of the file in 8.3 format.
+                  This attribute should only be set if there is a conflict between generated short file names
+                  or you wish to manually specify the short file name.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Delete" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    This attribute cannot be specified if the element is nested under a File element or the FileId attribute is specified. In other
+                    cases, if the attribute is not specified, the default value is "no" and the file is copied, not moved. Set the value to "yes"
+                    in order to move the file (thus deleting the source file) instead of copying it.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="File">
+    <xs:annotation>
+      <xs:documentation>
+        Defines a file to be installed by the package.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="File" href="https://learn.microsoft.com/en-us/windows/win32/msi/file-table" />
+        <xse:howtoRef href="files_and_registry/add_a_file.html">How To: Add a file to your installer</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="AssemblyName" />
+        <xs:element ref="Permission">
+          <xs:annotation>
+            <xs:documentation>Used to configure the ACLs for this file.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="PermissionEx">
+          <xs:annotation>
+            <xs:documentation>Can also configure the ACLs for this file.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="CopyFile">
+          <xs:annotation>
+            <xs:documentation>Used to create a duplicate of this file elsewhere.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="Shortcut">
+          <xs:annotation>
+            <xs:documentation>Target of the shortcut will be set to this file.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ODBCDriver" />
+        <xs:element ref="ODBCTranslator" />
+        <xs:element ref="SymbolPath" />
+        <xs:element ref="Class" />
+        <xs:element ref="AppId" />
+        <xs:element ref="TypeLib" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The unique identifier for this File element. If you omit Id, a stable identifier is generated for you.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="CompanionFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Set this attribute to make this file a companion child of another file. The installation
+            state of a companion file depends not on its own file versioning information, but on the versioning of its
+            companion parent. A file that is the key path for its component can not be a companion file (that means
+            this attribute cannot be set if KeyPath="yes" for this file). The Version attribute cannot be set along
+            with this attribute since companion files are not installed based on their own version.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="LongFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the name of the installed file. If this attribute is omitted, then
+            its default value is the file name portion of the Source attribute. If the
+            Source attribute is omitted, you must specify a Name attribute. For more
+            information, see <html:a href="~/howtos/general/specifying_source_files.html">Specifying source files</html:a>.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="KeyPath" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set to yes in order to force this file to be the key path for the parent component.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ShortName" type="ShortFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+            The short file name of the file in 8.3 format.
+            This attribute should only be set if there is a conflict between generated short file names
+            or the user wants to manually specify the short file name.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ReadOnly" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set to yes in order to have the file's read-only attribute set when it is installed on the target machine.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Hidden" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set to yes in order to have the file's hidden attribute set when it is installed on the target machine.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="System" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set to yes in order to have the file's system attribute set when it is installed on the target machine.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Vital" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>If a file is vital, then installation cannot proceed unless the file is successfully installed. The user will have no option to ignore an error installing this file. If an error occurs, they can merely retry to install the file or abort the installation. The default is "yes," unless the -sfdvital switch (candle.exe) or SuppressFileDefaultVital property (.wixproj) is used.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Checksum" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute should be set to "yes" for every executable file in the installation that has a valid checksum stored in the Portable Executable (PE) file header. Only those files that have this attribute set will be verified for valid checksum during a reinstall.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Compressed" type="YesNoDefaultTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Sets the file's source type compression. A setting of "yes"/"true", or "no"/"false" will override the setting in the Word Count Summary Property.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="BindPath" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>A list of paths, separated by semicolons, that represent the paths to be searched to find the imported DLLs. The list is usually a list of properties, with each property enclosed inside square brackets. The value may be set to an empty string. Including this attribute will cause an entry to be generated for the file in the BindImage table.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SelfRegCost" type="Integer">
+        <xs:annotation>
+          <xs:documentation>The cost of registering the file in bytes. This must be a non-negative number. Including this attribute will cause an entry to be generated for the file in the SelfReg table.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="TrueType" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Causes an entry to be generated for the file in the Font table with no FontTitle specified. This attribute is intended to be used to register the file as a TrueType font.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="FontTitle" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Causes an entry to be generated for the file in the Font table with the specified FontTitle. This attribute is intended to be used to register the file as a non-TrueType font.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DefaultLanguage" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>This is the default language of this file. The linker will replace this value from the value in the file if the suppress files option is not used.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DefaultSize" type="Integer">
+        <xs:annotation>
+          <xs:documentation>This is the default size of this file. The linker will replace this value from the value in the file if the suppress files option is not used.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DefaultVersion" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>This is the default version of this file. The linker will replace this value from the value in the file if the suppress files option is not used.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Assembly">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies if this File is a Win32 Assembly or .NET Assembly that needs to be installed into the
+            Global Assembly Cache (GAC). If the value is '.net' or 'win32', this file must also be the key path of the Component.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value=".net">
+              <xs:annotation>
+                <xs:documentation>
+                  The file is a .NET Framework assembly.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="no">
+              <xs:annotation>
+                <xs:documentation>
+                  The file is not a .NET Framework or Win32 assembly. This is the default value.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="win32">
+              <xs:annotation>
+                <xs:documentation>
+                  The file is a Win32 assembly.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="AssemblyManifest" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the file identifier of the manifest file that describes this assembly.
+            The manifest file should be in the same component as the assembly it describes.
+            This attribute may only be specified if the Assembly attribute is set to '.net' or 'win32'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="AssemblyApplication" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the file identifier of the application file. This assembly will be isolated
+            to the same directory as the application file.
+            If this attribute is absent, the assembly will be installed to the Global Assembly Cache (GAC).
+            This attribute may only be specified if the Assembly attribute is set to '.net' or 'win32'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProcessorArchitecture">
+        <xs:annotation>
+          <xs:documentation>Specifies the architecture for this assembly. This attribute should only be used on .NET Framework 2.0 or higher assemblies.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="msil">
+              <xs:annotation>
+                <xs:documentation>
+                  The file is a .NET Framework assembly that is processor-neutral.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="x86">
+              <xs:annotation>
+                <xs:documentation>
+                  The file is a .NET Framework assembly for the x86 processor.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="x64">
+              <xs:annotation>
+                <xs:documentation>
+                  The file is a .NET Framework assembly for the x64 processor.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ia64">
+              <xs:annotation>
+                <xs:documentation>
+                  The file is a .NET Framework assembly for the ia64 processor.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="DiskId" type="DiskIdType">
+        <xs:annotation>
+          <xs:documentation>
+            The value of this attribute should correspond to the Id attribute of a Media
+            element authored elsewhere. By creating this connection between a file and
+            its media, you set the packaging options to the values specified in the Media
+            element (values such as compression level, cab embedding, etc...). Specifying
+            the DiskId attribute on the File element overrides the default DiskId attribute
+            from the parent Component element. If no DiskId attribute is specified,
+            the default is "1". This DiskId attribute is ignored when creating a merge module
+            because merge modules do not have media.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Source" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the path to the file in the build process. Overrides default source
+            path set by parent directories and Name attribute. This attribute must be set
+            if no source information can be gathered from parent directories. For more
+            information, see <html:a href="~/howtos/general/specifying_source_files.html">Specifying source files</html:a>.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PatchGroup" type="Integer">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute must be set for patch-added files. Each patch should be assigned a different patch group number. Patch groups
+            numbers must be greater 0 and should be assigned consecutively. For example, the first patch should use PatchGroup='1', the
+            second patch will have PatchGroup='2', etc...
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PatchIgnore" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Prevents the updating of the file that is in fact changed in the upgraded image relative to the target images.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PatchAllowIgnoreOnError" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set to indicate that the patch is non-vital.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PatchWholeFile" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set if the entire file should be installed rather than creating a binary patch.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MultiString">
+    <xs:annotation>
+      <xs:documentation>
+        Use several of these elements to specify each registry value in a multiString registry value. This element
+        cannot be used if the Value attribute is specified unless the Type attribute is set to 'multiString'.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Registry" href="https://learn.microsoft.com/en-us/windows/win32/msi/registry-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The multi-string value.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MultiStringValue">
+    <xs:annotation>
+      <xs:documentation>
+        Use several of these elements to specify each registry value in a multiString registry value. This element
+        cannot be used if the Value attribute is specified unless the Type attribute is set to 'multiString'.
+
+        Consider using the MultiString element instead.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="MultiString" />
+        <xse:msiRef table="Registry" href="https://learn.microsoft.com/en-us/windows/win32/msi/registry-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The multi-string value.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RegistryKey">
+    <xs:annotation>
+      <xs:documentation>
+        Used for organization of child RegistryValue elements or to create a registry key
+        (and optionally remove it during uninstallation).
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Registry" href="https://learn.microsoft.com/en-us/windows/win32/msi/registry-table" />
+        <xse:howtoRef href="files_and_registry/read_a_registry_entry.html">How To: Read a registry entry during installation</xse:howtoRef>
+        <xse:howtoRef href="files_and_registry/write_a_registry_entry.html">How To: Write a registry entry during installation</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="RegistryKey" />
+        <xs:element ref="RegistryValue" />
+        <xs:element ref="Permission" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>ACL permission</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="PermissionEx">
+          <xs:annotation>
+            <xs:documentation>Can also configure the ACLs for this registry key.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Primary key used to identify this particular entry. If this attribute is not specified, an identifier will be
+            generated.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Action">
+        <xs:annotation>
+          <xs:documentation>
+            The Action attribute has been deprecated. In most cases, you can simply omit @Action. If you need to force Windows Installer
+            to create an empty key or recursively delete the key, use the ForceCreateOnInstall or ForceDeleteOnUninstall attributes instead.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="create">
+              <xs:annotation>
+                <xs:documentation>
+                  Creates the key, if absent, when the parent component is installed.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="createAndRemoveOnUninstall">
+              <xs:annotation>
+                <xs:documentation>
+                  Creates the key, if absent, when the parent component is installed then remove the key with all its values and subkeys when the parent component is uninstalled.
+                  Note that this value is useful only if your program creates additional values or subkeys under this key and you want an uninstall to remove them. MSI already
+                  removes all values and subkeys that it creates, so this option just adds additional overhead to uninstall.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="none">
+              <xs:annotation>
+                <xs:documentation>
+                  Does nothing; this element is used merely in WiX authoring for organization and does nothing to the final output.
+                  This is the default value.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ForceCreateOnInstall" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Set this attribute to 'yes' to create an empty key, if absent, when the parent component is installed.
+            This value is needed only to create an empty key with no subkeys or values. Windows Installer creates
+            keys as needed to store subkeys and values. The default is "no".
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ForceDeleteOnUninstall" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Set this attribute to 'yes' to remove the key with all its values and subkeys when the parent component is uninstalled.
+            Note that this value is useful only if your program creates additional values or subkeys under this key and you want an uninstall to remove them. MSI already
+            removes all values and subkeys that it creates, so this option just adds additional overhead to uninstall.
+            The default is "no".
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Key" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The localizable key for the registry value.
+            If the parent element is a RegistryKey, this value may be omitted to use the
+            path of the parent, or if its specified it will be appended to the path of the parent.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Root" type="RegistryRootType">
+        <xs:annotation>
+          <xs:documentation>
+            The predefined root key for the registry value.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RegistryValue">
+    <xs:annotation>
+      <xs:documentation>
+        Used to create a registry value. For multi-string values, this can be used to prepend or append values.
+
+        For legacy authoring: Use several of these elements to specify each registry value in a multiString registry value. This element
+        cannot be used if the Value attribute is specified unless the Type attribute is set to 'multiString'.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Registry" href="https://learn.microsoft.com/en-us/windows/win32/msi/registry-table" />
+        <xse:howtoRef href="files_and_registry/write_a_registry_entry.html">How To: Write a registry entry during installation</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Permission" />
+        <xs:element ref="PermissionEx">
+          <xs:annotation>
+            <xs:documentation>Can also configure the ACLs for this registry value.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="MultiString" />
+        <xs:element ref="MultiStringValue" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Primary key used to identify this particular entry. If this attribute is not specified, an identifier will be
+            generated by hashing the parent Component identifier, Root, Key, and Name.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Root" type="RegistryRootType">
+        <xs:annotation>
+          <xs:documentation>
+            The predefined root key for the registry value.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Key" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The localizable key for the registry value.
+            If the parent element is a RegistryKey, this value may be omitted to use the
+            path of the parent, or if its specified it will be appended to the path of the parent.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The localizable registry value name. If this attribute is not provided the default value for the registry key will
+            be set instead. The Windows Installer allows several special values to be set for this attribute. You should not
+            use them in WiX. Instead use appropriate values in the Action attribute to get the desired behavior.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Set this attribute to the localizable registry value. This value is formatted. The Windows Installer allows
+            several special values to be set for this attribute. You should not use them in WiX. Instead use appropriate
+            values in the Type attribute to get the desired behavior.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Type">
+        <xs:annotation>
+          <xs:documentation>
+            Set this attribute to the type of the desired registry key. This attribute must be specified whenever the Value
+            attribute or a child RegistryValue element is specified. This attribute
+            should only be set when the value of the Action attribute does not include the word 'remove'.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="string">
+              <xs:annotation>
+                <xs:documentation>
+                  The value is interpreted and stored as a string (REG_SZ).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="integer">
+              <xs:annotation>
+                <xs:documentation>
+                  The value is interpreted and stored as an integer (REG_DWORD).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="binary">
+              <xs:annotation>
+                <xs:documentation>
+                  The value is interpreted and stored as a hexadecimal value (REG_BINARY).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="expandable">
+              <xs:annotation>
+                <xs:documentation>
+                  The value is interpreted and stored as an expandable string (REG_EXPAND_SZ).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="multiString">
+              <xs:annotation>
+                <xs:documentation>
+                  The value is interpreted and stored as a multiple strings (REG_MULTI_SZ).
+                  Please note that this value will only result in a multi-string value if there is more than one registry value
+                  or the Action attribute's value is 'append' or 'prepend'. Otherwise a string value will be created.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Action">
+        <xs:annotation>
+          <xs:documentation>
+            This is the action that will be taken for this registry value.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="append">
+              <xs:annotation>
+                <xs:documentation>
+                  Appends the specified value(s) to a multiString registry value.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="prepend">
+              <xs:annotation>
+                <xs:documentation>
+                  Prepends the specified value(s) to a multiString registry value.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="write">
+              <xs:annotation>
+                <xs:documentation>
+                  Writes a registry value. This is the default value.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="KeyPath" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Set this attribute to 'yes' to make this registry key the KeyPath of the parent component.
+            Only one resource (registry, file, etc) can be the KeyPath of a component.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RemoveRegistryKey">
+    <xs:annotation>
+      <xs:documentation>
+        Used for removing registry keys and all child keys during install or uninstall.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Registry" href="https://learn.microsoft.com/en-us/windows/win32/msi/registry-table" />
+        <xse:msiRef table="RemoveRegistry" href="http://msdn.microsoft.com/library/aa371208.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Primary key used to identify this particular entry. If this attribute is not specified, an identifier will be
+            generated by hashing the parent Component identifier, Root, Key, and Name.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Action">
+        <xs:annotation>
+          <xs:documentation>
+            This is the action that will be taken for this registry value.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="removeOnInstall">
+              <xs:annotation>
+                <xs:documentation>
+                  Removes a key with all its values and subkeys when the parent component is installed.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="removeOnUninstall">
+              <xs:annotation>
+                <xs:documentation>
+                  Removes a key with all its values and subkeys when the parent component is uninstalled.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Key" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The localizable key for the registry value.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Root" type="RegistryRootType">
+        <xs:annotation>
+          <xs:documentation>
+            The predefined root key for the registry value.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RemoveRegistryValue">
+    <xs:annotation>
+      <xs:documentation>
+        Used to remove a registry value during installation.
+        There is no standard way to remove a single registry value during uninstall (but you can remove an entire key with RemoveRegistryKey).
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="RemoveRegistry" href="https://docs.microsoft.com/en-us/windows/win32/msi/removeregistry-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Primary key used to identify this particular entry. If this attribute is not specified, an identifier will be
+            generated by hashing the parent Component identifier, Root, Key, and Name.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Key" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The localizable key for the registry value.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The localizable registry value name. If this attribute is not provided the default value for the registry key will
+            be set instead. The Windows Installer allows several special values to be set for this attribute. You should not
+            use them in WiX. Instead use appropriate values in the Action attribute to get the desired behavior.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Root" type="RegistryRootType">
+        <xs:annotation>
+          <xs:documentation>
+            The predefined root key for the registry value.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RemoveFile">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="CopyFile" />
+        <xse:msiRef table="RemoveFile" href="https://learn.microsoft.com/en-us/windows/win32/msi/removefile-table" />
+      </xs:appinfo>
+      <xs:documentation>
+        Remove a file(s) if the parent component is selected for installation or removal. Multiple files can be removed
+        by specifying a wildcard for the value of the Name attribute. By default, the source
+        directory of the file is the directory of the parent component. This can be overridden by specifying the
+        Directory attribute with a value corresponding to the Id of the source directory, or by specifying the Property
+        attribute with a value corresponding to a property that will have a value that resolves to the full path
+        to the source directory.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Primary key used to identify this particular entry.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Directory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Overrides the directory of the parent component with a specific Directory. This Directory must exist in the
+            installer database at creation time. This attribute cannot be specified in conjunction with the Property attribute.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Property" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Overrides the directory of the parent component with the value of the specified property. The property
+            should have a value that resolves to the full path of the source directory. The property does not have
+            to exist in the installer database at creation time; it could be created at installation time by a custom
+            action, on the command line, etc. This attribute cannot be specified in conjunction with the Directory attribute.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="WildCardLongFileNameType" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            This value should be set to the localizable name of the file(s) to be removed. All of the files that
+            match the wild card will be removed from the specified directory. The value is a filename that may also
+            contain the wild card characters "?" for any single character or "*" for zero or more occurrences of any character.
+            In prior versions of the WiX toolset, this attribute specified the short file name.
+            This attribute's value may now be either a short or long file name.
+            If a short file name is specified, the ShortName attribute may not be specified.
+            Also, if this value is a long file name, the ShortName attribute may be omitted to
+            allow WiX to attempt to generate a unique short file name.
+            However, if you wish to manually specify the short file name, then the ShortName attribute may be specified.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ShortName" type="WildCardShortFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+            The short file name of the file in 8.3 format.
+            This attribute should only be set if you want to manually specify the short file name.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="On" type="InstallUninstallType" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            This value determines the time at which the file(s) may be removed. For 'install', the file will
+            be removed only when the parent component is being installed (msiInstallStateLocal or
+            msiInstallStateSource); for 'uninstall', the file will be removed only when the parent component
+            is being removed (msiInstallStateAbsent); for 'both', the file will be removed in both cases.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Subdirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute defines one or more directories below the directory referenced by the Directory attribute or parent
+            Directory reference for the file to be removed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RemoveFolder">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="CreateFolder" />
+        <xse:msiRef table="RemoveFile" href="https://learn.microsoft.com/en-us/windows/win32/msi/removefile-table" />
+      </xs:appinfo>
+      <xs:documentation>
+        Remove an empty folder if the parent component is selected for installation or removal. By default, the folder
+        is the directory of the parent component. This can be overridden by specifying the Directory attribute
+        with a value corresponding to the Id of the directory, or by specifying the Property attribute with a value
+        corresponding to a property that will have a value that resolves to the full path of the folder.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Primary key used to identify this particular entry.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Directory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Overrides the directory of the parent component with a specific Directory. This Directory must exist in the
+            installer database at creation time. This attribute cannot be specified in conjunction with the Property attribute.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Property" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Overrides the directory of the parent component with the value of the specified property. The property
+            should have a value that resolves to the full path of the source directory. The property does not have
+            to exist in the installer database at creation time; it could be created at installation time by a custom
+            action, on the command line, etc. This attribute cannot be specified in conjunction with the Directory attribute.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="On" type="InstallUninstallType" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            This value determines the time at which the folder may be removed, based on the install/uninstall of the parent component.
+            For 'install', the folder will be removed only when the parent component is being installed (msiInstallStateLocal or
+            msiInstallStateSource); for 'uninstall', the folder will be removed only when the parent component
+            is being removed (msiInstallStateAbsent); for 'both', the folder will be removed in both cases.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Subdirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute defines one or more directories below the directory referenced by the Directory attribute or parent
+            Directory reference for the folder to be removed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CreateFolder">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="RemoveFolder" />
+        <xse:msiRef table="CreateFolder" href="https://learn.microsoft.com/en-us/windows/win32/msi/createfolder-table" />
+      </xs:appinfo>
+      <xs:documentation>Create folder as part of parent Component.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Shortcut" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Non-advertised shortcut to this folder, Shortcut Target is preset to the folder</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="Permission" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>ACL permission</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="PermissionEx">
+          <xs:annotation>
+            <xs:documentation>Can also configure the ACLs for this folder.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Directory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Identifier of Directory to create. Defaults to Directory of parent Component.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Subdirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute defines one or more directories below the directory referenced by the Directory attribute or parent
+            Directory reference for the directory to be created.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Category">
+    <xs:annotation>
+      <xs:documentation>
+        Qualified published component for parent Component
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="PublishComponent" href="https://learn.microsoft.com/en-us/windows/win32/msi/publishcomponent-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" use="required" type="Guid">
+        <xs:annotation>
+          <xs:documentation>A string GUID that represents the category of components being grouped together.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Qualifier" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>A text string that qualifies the value in the Id attribute. A qualifier is used to distinguish multiple forms of the same Component, such as a Component that is implemented in multiple languages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="AppData" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>An optional localizable text describing the category. The string is commonly parsed by the application and can be displayed to the user. It should describe the category.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Feature" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Feature that controls the advertisement of the category. Defaults to the primary Feature for the parent Component .</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MIME">
+    <xs:annotation>
+      <xs:documentation>
+                MIME content-type for an Extension
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MIME" href="http://msdn.microsoft.com/library/aa370035.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Advertise" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Whether this MIME is to be advertised. The default is to match whatever the parent extension element uses. If the parent element is not advertised, then this element cannot be advertised either.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ContentType" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>This is the identifier for the MIME content. It is commonly written in the form of type/format.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Class" type="Guid">
+        <xs:annotation>
+          <xs:documentation>Class ID for the COM server that is to be associated with the MIME content.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Default" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>If 'yes', become the content type for the parent Extension. The default value is 'no'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Verb">
+    <xs:annotation>
+      <xs:documentation>
+            Verb definition for an Extension. When advertised, this element creates a row in the
+            <html:a href="https://learn.microsoft.com/en-us/windows/win32/msi/verb-table">Verb table</html:a>.
+            When not advertised, this element creates the appropriate rows in <html:a href="https://learn.microsoft.com/en-us/windows/win32/msi/registry-table">Registry table</html:a>.
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Verb" href="https://learn.microsoft.com/en-us/windows/win32/msi/verb-table" />
+        <xse:msiRef table="Registry" href="https://learn.microsoft.com/en-us/windows/win32/msi/registry-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The verb for the command.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Command" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The localized text displayed on the context menu.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Argument" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Value for the command arguments. Note that the resolution of properties in the
+                Argument field is limited. A property formatted as [Property] in this field can only be resolved if the property
+                already has the intended value when the component owning the verb is installed. For example, for the argument
+                "[#MyDoc.doc]" to resolve to the correct value, the same process must be installing the file MyDoc.doc and the
+                component that owns the verb.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Sequence" type="Integer">
+        <xs:annotation>
+          <xs:documentation>The sequence of the commands. Only verbs for which the Sequence is specified
+                are used to prepare an ordered list for the default value of the shell key. The Verb with the lowest value in this
+                column becomes the default verb. Used only for Advertised verbs.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="TargetFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                        Either this attribute or the TargetProperty attribute must be specified for a non-advertised verb.
+                        The value should be the identifier of the target file to be executed for the verb.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="TargetProperty" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                        Either this attribute or the TargetFile attribute must be specified for a non-advertised verb.
+                        The value should be the identifier of the property which will resolve to the path to the target file to be executed for the verb.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Extension">
+    <xs:annotation>
+      <xs:documentation>
+                Extension for a Component
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MIME" href="http://msdn.microsoft.com/library/aa370035.aspx" />
+        <xse:msiRef table="Verb" href="https://learn.microsoft.com/en-us/windows/win32/msi/verb-table" />
+        <xse:msiRef table="Registry" href="https://learn.microsoft.com/en-us/windows/win32/msi/registry-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>MIME and Verbs can be associated with Extensions</xs:documentation>
+        </xs:annotation>
+        <xs:element ref="MIME" />
+        <xs:element ref="Verb" />
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>This is simply the file extension, like "doc" or "xml". Do not include the preceding period.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ContentType" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The MIME type that is to be written.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Advertise" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Whether this extension is to be advertised. The default is "no".</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+                    Extensibility point in the WiX XML Schema. Schema extensions can register additional
+                    attributes at this point in the schema.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="TypeLib">
+    <xs:annotation>
+      <xs:documentation>
+                Register a type library (TypeLib). Please note that in order to properly use this
+                non-advertised, you will need use this element with Advertise='no' and also author the
+                appropriate child Interface elements by extracting them from the type library itself.
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="TypeLib" href="http://msdn.microsoft.com/library/aa372092.aspx" />
+        <xse:msiRef table="Registry" href="https://learn.microsoft.com/en-us/windows/win32/msi/registry-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="AppId" />
+        <xs:element ref="Class" />
+        <xs:element ref="Interface" />
+      </xs:choice>
+      <xs:attribute name="Id" type="Guid" use="required">
+        <xs:annotation>
+          <xs:documentation>The GUID that identifes the type library.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Advertise" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    Value of 'yes' will create a row in the TypeLib table.
+                    Value of 'no' will create rows in the Registry table.
+                    The default value is 'no'.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Control" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Value of 'yes' means the type library describes controls, and should not be displayed in type browsers intended for nonvisual objects.
+            This attribute can only be set if Advertise='no'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Cost" type="xs:int">
+        <xs:annotation>
+          <xs:documentation>
+            The cost associated with the registration of the type library in bytes. This attribute cannot be set if Advertise='no'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Description" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The localizable description of the type library.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="HasDiskImage" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Value of 'yes' means the type library exists in a persisted form on disk. This attribute can only be set if Advertise='no'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="HelpDirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The identifier of the Directory element for the help directory.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="HelpSubirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute defines one or more directories below the directory referenced by the HelpDirectory attribute
+            for the typelib's help directory.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Hidden" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Value of 'yes' means the type library should not be displayed to users, although its use is not restricted.
+            Should be used by controls. Hosts should create a new type library that wraps the control with extended properties.
+            This attribute can only be set if Advertise='no'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Language" use="required" type="Integer">
+        <xs:annotation>
+          <xs:documentation>The language of the type library. This must be a non-negative integer.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MajorVersion" type="Integer">
+        <xs:annotation>
+          <xs:documentation>The major version of the type library. The value should be an integer from 0 - 255.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MinorVersion" type="Integer">
+        <xs:annotation>
+          <xs:documentation>The minor version of the type library. The value should be an integer from 0 - 255.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ResourceId" type="Integer">
+        <xs:annotation>
+          <xs:documentation>The resource id of a typelib. The value is appended to the end of the typelib path in the registry.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Restricted" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    Value of 'yes' means the type library is restricted, and should not be displayed to users. This attribute can only be set if Advertise='no'.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ProgId">
+    <xs:annotation>
+      <xs:documentation>
+                ProgId registration for parent Component. If ProgId has an associated Class, it must be a child of that element.
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="ProgId" href="http://msdn.microsoft.com/library/aa370879.aspx" />
+        <xse:msiRef table="Class" href="http://msdn.microsoft.com/library/aa367861.aspx" />
+        <xse:msiRef table="Registry" href="https://learn.microsoft.com/en-us/windows/win32/msi/registry-table" />
+        <xse:msiRef table="Icon" href="http://msdn.microsoft.com/library/aa369210.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="ProgId" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>The version-independent ProgId must be the first child element of actual ProgId. Nesting other ProgId elements within the Version-independent ProgId will create COM+ aliases, see <html:a href="http://support.microsoft.com/kb/305745">http://support.microsoft.com/kb/305745</html:a> for more information.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="Extension" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Extensions that refer to this ProgId</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="Id" type="xs:string" use="required" />
+      <xs:attribute name="Description" type="xs:string" />
+      <xs:attribute name="Icon" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>For an advertised ProgId, the Id of an Icon element. For a non-advertised ProgId, this is the Id of a file containing an icon resource.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IconIndex" type="Integer" />
+      <xs:attribute name="Advertise" type="YesNoTypeUnion" />
+      <xs:attribute name="NoOpen" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Specifies that the associated ProgId should not be opened by users. The value is presented as a warning to users. An empty string is also valid for this attribute.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AppId">
+    <xs:annotation>
+      <xs:documentation>
+                Application ID containing DCOM information for the associated application GUID.
+                If this element is nested under a Fragment, Module, or Package element, it must be
+                advertised.
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="AppId" href="http://msdn.microsoft.com/library/aa367566.aspx" />
+        <xse:msiRef table="Registry" href="https://learn.microsoft.com/en-us/windows/win32/msi/registry-table" />
+        <xse:remarks>
+          When being used in unadvertised mode, the attributes in the AppId element correspond to registry values
+          under the `[HKCR\AppID\{Id}]` key, as follows:
+
+          - `Id`: [HKCR\AppID\`Id`]
+          - `ActivateAtStorage`: [HKCR\AppID\`Id`]/ActivateAtStorage="Y"
+          - `Description`: [HKCR\AppID\`Id`]/@="My AppId Description"
+          - `DllSurrogate`: [HKCR\AppID\`Id`]/DllSurrogate="C:\surrogate.exe"
+          - `LocalService`: [HKCR\AppID\`Id`]/LocalService="MyServiceName"
+          - `RemoteServerName`: [HKCR\AppID\`Id`]/RemoteServerName="MyRemoteServer"
+          - `RunAsInteractiveUser`: [HKCR\AppID\`Id`]/RunAs="Interactive User"
+          - `ServiceParameters`: [HKCR\AppID\`Id`]/ServiceParameters="-param"
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Class" />
+      </xs:choice>
+      <xs:attribute name="ActivateAtStorage" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    Set this value to 'yes' to configure the client to activate on the same system as persistent storage.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Advertise" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    Set this value to 'yes' in order to create a normal AppId table row. Set this value to 'no' in order to
+                    generate Registry rows that perform similar registration (without the often problematic Windows Installer
+                    advertising behavior).
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Description" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    Set this value to the description of the AppId. It can only be specified when the AppId is not being advertised.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DllSurrogate" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    Set this value to specify that the class is a DLL that is to be activated in a surrogate EXE
+                    process, and the surrogate process to be used is the path of a surrogate EXE file specified by the value.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Id" type="Guid" use="required">
+        <xs:annotation>
+          <xs:documentation>
+                    Set this value to the AppID GUID that corresponds to the named executable.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="LocalService" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    Set this value to the name of a service to allow the object to be installed as a Win32 service.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RemoteServerName" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    Set this value to the name of the remote server to configure the client to request the object
+                    be run at a particular machine whenever an activation function is called for which a COSERVERINFO
+                    structure is not specified.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RunAsInteractiveUser" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    Set this value to 'yes' to configure a class to run under the identity of the user currently
+                    logged on and connected to the interactive desktop when activated by a remote client without
+                    being written as a Win32 service.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ServiceParameters" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    Set this value to the parameters to be passed to a LocalService on invocation.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Class">
+    <xs:annotation>
+      <xs:documentation>COM Class registration for parent Component.</xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="AppId" />
+        <xse:msiRef table="Class" href="http://msdn.microsoft.com/library/aa367861.aspx" />
+        <xse:msiRef table="ProgId" href="http://msdn.microsoft.com/library/aa370879.aspx" />
+        <xse:msiRef table="Registry" href="https://learn.microsoft.com/en-us/windows/win32/msi/registry-table" />
+        <xse:msiRef table="AppId" href="http://msdn.microsoft.com/library/aa367566.aspx" />
+        <xse:remarks>
+          When being used in unadvertised mode, the attributes in the Class element correspond to registry
+          values under the `[HKCR\CLSID\{'{'}Id{'}'}]` and `[HKCR\CLSID\{'{'}Id{'}'}\Context]` keys as follows:
+
+          - `Id, Context`: [HKCR\CLSID\{'{'}Id{'}'}\Context]
+          - `Server`: [HKCR\CLSID\{01234567-89AB-CDEF-0123-456789ABCDEF}\LocalServer32]\@="[!comserv.dll]"
+          - `ForeignServer`: [HKCR\CLSID\{01234567-89AB-CDEF-0123-456789ABCDEF}\LocalServer32]\@="mscoree.dll"
+          - `AppId`: [HKCR\CLSID\{01234567-89AB-CDEF-0123-456789ABCDEF}]\AppId="{00000000-89AB-0000-0123-000000000000}"
+          - `Argument`: [HKCR\CLSID\{01234567-89AB-CDEF-0123-456789ABCDEF}\LocalServer32]\@="[!comserv.dll] /arg1 /arg2 /arg3"
+          - `Control`: [HKCR\CLSID\{01234567-89AB-CDEF-0123-456789ABCDEF}\Control]
+          - `Description`: [HKCR\CLSID\{01234567-89AB-CDEF-0123-456789ABCDEF}]\@="Description of Example COM Component"
+          - `Handler`: [HKCR\CLSID\{01234567-89AB-CDEF-0123-456789ABCDEF}\InprocHandler32]\@="handler.dll"
+          - `Insertable`: [HKCR\CLSID\{01234567-89AB-CDEF-0123-456789ABCDEF}\Insertable]
+          - `Insertable`: [HKCR\CLSID\{01234567-89AB-CDEF-0123-456789ABCDEF}\NotInsertable]
+          - `Programmable`: [HKCR\CLSID\{01234567-89AB-CDEF-0123-456789ABCDEF}\Programmable]
+          - `SafeForInitializing`: [HKCR\CLSID\{01234567-89AB-CDEF-0123-456789ABCDEF}\Implemented Categories\{7DD95801-9882-11CF-9FA9-00AA006C42C4}]
+          - `ThreadingModel`: [HKCR\CLSID\{01234567-89AB-CDEF-0123-456789ABCDEF}\LocalServer32]\ThreadingModel="Apartment"
+          - `TypeLibId`: [HKCR\CLSID\{01234567-89AB-CDEF-0123-456789ABCDEF}\TypeLib]\@="{11111111-89AB-1111-0123-111111111111}"
+          - `Version`: [HKCR\CLSID\{01234567-89AB-CDEF-0123-456789ABCDEF}\Version]\@="1.0.0.0"
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="ProgId">
+          <xs:annotation>
+            <xs:documentation>A ProgId associated with Class must be a child element of the Class element</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="FileTypeMask" />
+        <xs:element ref="Interface">
+          <xs:annotation>
+            <xs:documentation>These Interfaces will be registered with the parent Class and TypeLib (if present).</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="Id" type="Guid" use="required">
+        <xs:annotation>
+          <xs:documentation>The Class identifier (CLSID) of a COM server.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Context">
+        <xs:annotation>
+          <xs:documentation>
+                  The server context(s) for this COM server. This attribute is optional for VB6 libraries that are marked "PublicNotCreateable".
+                  Class elements marked Advertised must specify at least one server context. It is most common for there to be a single value
+                  for the Context attribute.
+                </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:list>
+            <xs:simpleType>
+              <xs:restriction base="xs:NMTOKEN">
+                <xs:enumeration value="LocalServer">
+                  <xs:annotation>
+                    <xs:documentation>
+                                            A 16-bit local server application.
+                                        </xs:documentation>
+                  </xs:annotation>
+                </xs:enumeration>
+                <xs:enumeration value="LocalServer32">
+                  <xs:annotation>
+                    <xs:documentation>
+                                            A 32-bit local server application.
+                                        </xs:documentation>
+                  </xs:annotation>
+                </xs:enumeration>
+                <xs:enumeration value="InprocServer">
+                  <xs:annotation>
+                    <xs:documentation>
+                                            A 16-bit in-process server DLL.
+                                        </xs:documentation>
+                  </xs:annotation>
+                </xs:enumeration>
+                <xs:enumeration value="InprocServer32">
+                  <xs:annotation>
+                    <xs:documentation>
+                                            A 32-bit in-process server DLL.
+                                        </xs:documentation>
+                  </xs:annotation>
+                </xs:enumeration>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:list>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Description" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Localized description associated with the Class ID and Program ID.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="AppId" type="Guid">
+        <xs:annotation>
+          <xs:documentation>
+                    This attribute is only allowed when a Class is advertised. Using this attribute will reference an Application ID
+                    containing DCOM information for the associated application GUID. The value must correspond to an AppId/@Id of an
+                    AppId element nested under a Fragment, Module, or Package element. To associate an AppId with a non-advertised
+                    class, nest the class within a parent AppId element.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Icon" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    The file providing the icon associated with this CLSID. Reference to an Icon element
+                    (should match the Id attribute of an Icon element). This is currently not supported if the
+                    value of the Advertise attribute is "no".
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IconIndex" type="Integer">
+        <xs:annotation>
+          <xs:documentation>Icon index into the icon file.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Handler" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    The default inproc handler. May be optionally provided only for Context = LocalServer or
+                    LocalServer32. Value of "1" creates a 16-bit InprocHandler (appearing as the InprocHandler
+                    value). Value of "2" creates a 32-bit InprocHandler (appearing as the InprocHandler32 value).
+                    Value of "3" creates 16-bit as well as 32-bit InprocHandlers. A non-numeric value is treated
+                    as a system file that serves as the 32-bit InprocHandler (appearing as the InprocHandler32 value).
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Argument" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    This column is optional only when the Context column is set to "LocalServer"
+                    or "LocalServer32" server context. The text is registered as the argument against
+                    the OLE server and is used by OLE for invoking the server. Note that the resolution
+                    of properties in the Argument field is limited. A property formatted as [Property] in
+                    this field can only be resolved if the property already has the intended value when
+                    the component owning the class is installed. For example, for the argument "[#MyDoc.doc]"
+                    to resolve to the correct value, the same process must be installing the file MyDoc.doc and the
+                    component that owns the class.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RelativePath" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    When the value is "yes", the bare file name can be used for COM servers. The installer
+                    registers the file name only instead of the complete path. This enables the server in
+                    the current directory to take precedence and allows multiple copies of the same component.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Advertise" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    Set this value to "yes" in order to create a normal Class table row. Set this value to
+                    "no" in order to generate Registry rows that perform similar registration (without the
+                    often problematic Windows Installer advertising behavior).
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <!-- Following attributes are not advertised, but add the appropriate rows to the Registry table -->
+      <xs:attribute name="ThreadingModel">
+        <xs:annotation>
+          <xs:documentation>
+                    Threading model for the CLSID.
+                </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="apartment" />
+            <xs:enumeration value="free" />
+            <xs:enumeration value="both" />
+            <xs:enumeration value="neutral" />
+            <xs:enumeration value="single" />
+            <xs:enumeration value="rental" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Version" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    Version for the CLSID.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Insertable" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    Specifies the CLSID may be insertable.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Programmable" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    Specifies the CLSID may be programmable.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ForeignServer" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                  May only be specified if the value of the Advertise attribute is "no" and Server has not been specified. In addition, it may only
+                  be used when the Class element is directly under the Component element. The value can be
+                  that of an registry type (REG_SZ). This attribute should be used to specify foreign servers, such as mscoree.dll if needed.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Server" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                    May only be specified if the value of the Advertise attribute is "no" and the ForeignServer attribute is not specified. File Id of the
+                    COM server file. If this element is nested under a File element, this value defaults to
+                    the value of the parent File/@Id.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ShortPath" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                        Specifies whether or not to use the short path for the COM server. This can only apply when Advertise is set to 'no'. The default is 'no' meaning that it will use the long file name for the COM server.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SafeForScripting" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    May only be specified if the value of the Advertise attribute is "no".
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SafeForInitializing" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    May only be specified if the value of the Advertise attribute is "no".
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Control" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    Set this attribute's value to 'yes' to identify an object as an ActiveX Control. The default value is 'no'.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Interface">
+    <xs:annotation>
+      <xs:documentation>COM Interface registration for parent TypeLib.</xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Registry" href="https://learn.microsoft.com/en-us/windows/win32/msi/registry-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="Guid" use="required">
+        <xs:annotation>
+          <xs:documentation>GUID identifier for COM Interface.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Name for COM Interface.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="BaseInterface" type="Guid">
+        <xs:annotation>
+          <xs:documentation>Identifies the interface from which the current interface is derived.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProxyStubClassId" type="Guid">
+        <xs:annotation>
+          <xs:documentation>GUID CLSID for proxy stub to COM Interface.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProxyStubClassId32" type="Guid">
+        <xs:annotation>
+          <xs:documentation>GUID CLSID for 32-bit proxy stub to COM Interface.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="NumMethods" type="Integer">
+        <xs:annotation>
+          <xs:documentation>Number of methods implemented on COM Interface.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Versioned" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Determines whether a Typelib version entry should be created with the other COM Interface registry keys. Default is 'yes'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="FileTypeMask">
+    <xs:annotation>
+      <xs:documentation>FileType data for class Id registration.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Offset" type="Integer" use="required">
+        <xs:annotation>
+          <xs:documentation>Offset into file. If positive, offset is from the beginning; if negative, offset is from the end.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Mask" type="HexType" use="required">
+        <xs:annotation>
+          <xs:documentation>Hex value that is AND'd against the bytes in the file at Offset.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="HexType" use="required">
+        <xs:annotation>
+          <xs:documentation>If the result of the AND'ing of Mask with the bytes in the file is Value, the file is a match for this File Type.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ServiceDependency">
+    <xs:annotation>
+      <xs:documentation>
+        Service or group of services that must start before the parent service.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="ServiceInstall" href="https://docs.microsoft.com/en-us/windows/win32/msi/serviceinstall-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The name (not the display name) of a previously installed service or the name of a service group when the Group attribute is set to 'yes'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Group" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Set to 'yes' to indicate that the value in the Id attribute is the name of a group of services. If 'no' or not set, the Id attribute refers to another service by name.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ServiceInstall">
+    <xs:annotation>
+      <xs:documentation>
+        Adds services for parent Component. Use the ServiceControl element to remove services.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="ServiceInstall" href="https://docs.microsoft.com/en-us/windows/win32/msi/serviceinstall-table" />
+        <xse:remarks>
+          The service executable installed will point to the KeyPath for the Component.
+          Therefore, you must ensure that the correct executable is either the first child
+          File element under this Component or explicitly mark the appropriate File element
+          as KeyPath='yes'.
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="PermissionEx">
+          <xs:annotation>
+            <xs:documentation>Configures the ACLs for this service.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ServiceDependency">
+          <xs:annotation>
+            <xs:documentation>Ordered list of dependencies when installing services.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ServiceConfig" />
+        <xs:element ref="ServiceConfigFailureActions" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Unique identifier for this service configuration. This value will default to the Name attribute if not
+            specified.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>This column is the string that gives the service name to install.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DisplayName" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>This column is the localizable string that user interface programs use to identify the service.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Type" use="required">
+        <xs:annotation>
+          <xs:documentation>The Windows Installer does not currently support kernelDriver or systemDriver.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="ownProcess">
+              <xs:annotation>
+                <xs:documentation>
+                  A Win32 service that runs its own process.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="shareProcess">
+              <xs:annotation>
+                <xs:documentation>
+                  A Win32 service that shares a process.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="kernelDriver">
+              <xs:annotation>
+                <xs:documentation>
+                  A kernel driver service. This value is not currently supported by the Windows Installer.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="systemDriver">
+              <xs:annotation>
+                <xs:documentation>
+                  A file system driver service. This value is not currently supported by the Windows Installer.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Interactive" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Whether or not the service interacts with the desktop.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Start" use="required">
+        <xs:annotation>
+          <xs:documentation>Determines when the service should be started. The Windows Installer does not support boot or system.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="auto">
+              <xs:annotation>
+                <xs:documentation>
+                  The service will start during startup of the system.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="demand">
+              <xs:annotation>
+                <xs:documentation>
+                  The service will start when the service control manager calls the StartService function.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="disabled">
+              <xs:annotation>
+                <xs:documentation>
+                  The service can no longer be started.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="boot">
+              <xs:annotation>
+                <xs:documentation>
+                  The service is a device driver that will be started by the operating system boot loader. This value is not currently supported by the Windows Installer.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="system">
+              <xs:annotation>
+                <xs:documentation>
+                  The service is a device driver that will be started by the IoInitSystem function. This value is not currently supported by the Windows Installer.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ErrorControl" use="required">
+        <xs:annotation>
+          <xs:documentation>Determines what action should be taken on an error.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="ignore">
+              <xs:annotation>
+                <xs:documentation>
+                  Logs the error and continues with the startup operation.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="normal">
+              <xs:annotation>
+                <xs:documentation>
+                  Logs the error, displays a message box and continues the startup operation.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="critical">
+              <xs:annotation>
+                <xs:documentation>
+                  Logs the error if it is possible and the system is restarted with the last configuration known to be good. If the last-known-good configuration is being started, the startup operation fails.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Vital" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>When set to 'yes' or left unspecified the overall install will fail if this service fails to install. A value of 'no' indicates failure to install the service will be ignored.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="LoadOrderGroup" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The load ordering group that this service should be a part of.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Account" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Fully qualified names must be used even for local accounts, e.g.: ".\LOCAL_ACCOUNT". Valid only when ServiceType is ownProcess.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Password" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The password for the account. Valid only when the account has a password.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Arguments" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Contains any command line arguments or properties required to run the service.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Description" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Sets the description of the service.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="EraseDescription" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Determines whether the existing service description will be ignored. If 'yes', the service description will be null, even if the Description attribute is set.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ServiceArgument" type="xs:string">
+    <xs:annotation>
+      <xs:documentation>
+        Argument used in ServiceControl parent
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="ServiceControl" href="http://msdn.microsoft.com/library/aa371634.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="ServiceControl">
+    <xs:annotation>
+      <xs:documentation>
+        Starts, stops, and removes services for parent Component. This element is used to control the state
+        of a service installed by the MSI or MSM file by using the start, stop and remove attributes.
+        For example, Start='install' Stop='both' Remove='uninstall' would mean: start the service on install,
+        remove the service when the product is uninstalled, and stop the service both on install and uninstall.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="ServiceControl" href="http://msdn.microsoft.com/library/aa371634.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="ServiceArgument" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Ordered list of arguments used when modifying services.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Unique identifier for this service control. This value will default to the Name attribute if not
+            specified.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Name of the service.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Start" type="InstallUninstallType">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether the service should be started by the StartServices action on install, uninstall or both.
+            For 'install', the service will be started only when the parent component is being installed (msiInstallStateLocal or
+            msiInstallStateSource); for 'uninstall', the service will be started only when the parent component
+            is being removed (msiInstallStateAbsent); for 'both', the service will be started in both cases.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Stop" type="InstallUninstallType">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether the service should be stopped by the StopServices action on install, uninstall or both.
+            For 'install', the service will be stopped only when the parent component is being installed (msiInstallStateLocal or
+            msiInstallStateSource); for 'uninstall', the service will be stopped only when the parent component
+            is being removed (msiInstallStateAbsent); for 'both', the service will be stopped in both cases.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Remove" type="InstallUninstallType">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether the service should be removed by the DeleteServices action on install, uninstall or both.
+            For 'install', the service will be removed only when the parent component is being installed (msiInstallStateLocal or
+            msiInstallStateSource); for 'uninstall', the service will be removed only when the parent component
+            is being removed (msiInstallStateAbsent); for 'both', the service will be removed in both cases.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Wait" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Specifies whether or not to wait for the service to complete before continuing. The default is 'yes'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RequiredPrivilege" type="xs:string">
+    <xs:annotation>
+      <xs:documentation>
+        Privilege required by service configured by ServiceConfig parent. Valid values are a <html:a href="http://msdn.microsoft.com/en-us/library/bb530716.aspx">privilege constant</html:a> or a
+        Formatted property that resolves to a privilege constant.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiServiceConfig" href="https://learn.microsoft.com/en-us/windows/win32/msi/msiserviceconfig-table" />
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="ServiceConfig">
+    <xs:annotation>
+      <xs:documentation>
+        Configures a service being installed or one that already exists. This element's functionality is available starting with MSI 5.0. However, a
+        [remark indicating the functionality does not work correctly](https://learn.microsoft.com/en-us/windows/win32/msi/msiconfigureservices-action) was added later.
+        Consider using the [util:ServiceConfig element](../../schema/util/serviceconfig.md) instead.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiServiceConfig" href="https://learn.microsoft.com/en-us/windows/win32/msi/msiserviceconfig-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="RequiredPrivilege">
+          <xs:annotation>
+            <xs:documentation>List of privileges to apply to service.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Unique identifier for this service configuration. This value will default to the ServiceName attribute if not
+            specified.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DelayedAutoStart" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies whether an auto-start service should delay its start until after all other auto-start
+            services. This attribute only affects auto-start services. Allowed values are "yes", "no" or a Formatted property that
+            resolves to "1" (for "yes") or "0" (for "no"). If this attribute is not present the setting is not configured.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="FailureActionsWhen" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies when failure actions should be applied. Allowed values are "failedToStop", "failedToStopOrReturnedError"
+            or a Formatted property that resolves to "1" (for "failedToStopOrReturnedError") or "0" (for "failedToStop"). If this attribute
+            is not present the setting is not configured.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PreShutdownDelay" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies time in milliseconds that the Service Control Manager (SCM) waits after notifying the service of a system
+            shutdown. If this attribute is not present the default value, 3 minutes, is used.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OnInstall" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether to configure the service when the parent Component is installed. This attribute may be combined with OnReinstall
+            and OnUninstall.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OnReinstall" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether to configure the service when the parent Component is reinstalled. This attribute may be combined with OnInstall
+            and OnUninstall.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OnUninstall" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether to configure the service when the parent Component is uninstalled. This attribute may be combined with OnInstall
+            and OnReinstall.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ServiceName" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the name of the service to configure. This value will default to the ServiceInstall/@Name attribute when nested under
+            a ServiceInstall element.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ServiceSid" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the service SID to apply to the service. Valid values are "none", "restricted", "unrestricted" or a Formatted property
+            that resolves to "0" (for "none"), "3" (for "restricted") or "1" (for "unrestricted"). If this attribute is not present the
+            setting is not configured.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Failure">
+    <xs:annotation>
+      <xs:documentation>Failure action for a ServiceConfigFailureActions element.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Action" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the action to take when the service fails. Valid values are "none", "restartComputer", "restartService", "runCommand" or a Formatted property
+            that resolves to "0" (for "none"), "1" (for "restartService"), "2" (for "restartComputer") or "3" (for "runCommand").
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Delay" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+                    Specifies the time in milliseconds to wait before performing the value from the Action attribute.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ServiceConfigFailureActions">
+    <xs:annotation>
+      <xs:documentation>
+                Configures the failure actions for a service being installed or one that already exists. This element's functionality is available starting with MSI 5.0.
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiServiceConfigFailureActions" href="https://learn.microsoft.com/en-us/windows/win32/msi/msiserviceconfigfailureactions-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Failure">
+          <xs:annotation>
+            <xs:documentation>Ordered list of failure actions to apply to service.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Unique identifier for this service configuration. This value will default to the ServiceName attribute if not
+            specified.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Command" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies command to execute when a "runCommand" failure action hit. If an empty string is provided it clears
+            the existing command. If this attribute is not present the setting is not changed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OnInstall" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether to configure the service when the parent Component is installed. This attribute may be combined with OnReinstall
+            and OnUninstall.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OnReinstall" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether to configure the service when the parent Component is reinstalled. This attribute may be combined with OnInstall
+            and OnUninstall.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OnUninstall" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies whether to configure the service when the parent Component is uninstalled. This attribute may be combined with OnInstall
+            and OnReinstall.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RebootMessage" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the message to show for a reboot failure action. If an empty string is provided it clears any existing reboot message. If this
+            attribute is not present the setting is not changed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ResetPeriod" type="Integer">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the time in seconds to reset the failure count. If this attribute is not present the failure count will not be reset.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ServiceName" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Specifies the name of the service to configure. This value will default to the ServiceInstall/@Name attribute when nested under
+            a ServiceInstall element.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Environment">
+    <xs:annotation>
+      <xs:documentation>
+        Environment variables added or removed for the parent component.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Environment" href="http://msdn.microsoft.com/library/aa368369.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Unique identifier for environment entry.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Name of the environment variable.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The value to set into the environment variable.
+            If this attribute is not set, the environment variable is removed during installation if it exists on the machine.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Separator" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Optional attribute to change the separator used between values. By default a semicolon is used.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Action">
+        <xs:annotation>
+          <xs:documentation>Specfies whether the environmental variable should be created, set or removed when the parent component is installed.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="create">
+              <xs:annotation>
+                <xs:documentation>Creates the environment variable if it does not exist, then set it during installation. This has no effect on the value of the environment variable if it already exists.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="set">
+              <xs:annotation>
+                <xs:documentation>Creates the environment variable if it does not exist, and then set it during installation. If the environment variable exists, set it during the installation.</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="remove">
+              <xs:annotation>
+                <xs:documentation>
+                  Removes the environment variable during an installation.
+                  The installer only removes an environment variable during an installation if the name and value
+                  of the variable match the entries in the Name and Value attributes.
+                  If you want to remove an environment variable, regardless of its value, do not set the Value attribute.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Part">
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="all">
+              <xs:annotation>
+                <xs:documentation>
+                  This value is the entire environmental variable. This is the default.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="first">
+              <xs:annotation>
+                <xs:documentation>
+                  This value is prefixed.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="last">
+              <xs:annotation>
+                <xs:documentation>
+                  This value is appended.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Permanent" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Specifies that the environment variable should not be removed on uninstall.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="System" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    Specifies that the environment variable should be added to the system environment space. The default
+                    is 'no' which indicates the environment variable is added to the user environment space.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Launch">
+    <xs:annotation>
+      <xs:documentation>
+        Launch conditions for MSI packages.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="LaunchCondition" href="https://docs.microsoft.com/en-us/windows/win32/msi/launchcondition-table" />
+        <xse:howtoRef href="redistributables_and_install_checks/block_install_on_os.html">How To: Block installation based on OS version</xse:howtoRef>
+        <xse:howtoRef href="files_and_registry/check_the_version_number.html">How To: Check the version number of a file during installation</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Condition" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The condition expression to be evaluated at install time.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Message" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Set the value to the text to display when the condition fails and the installation must be terminated.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Level">
+    <xs:annotation>
+      <xs:documentation>
+        Feature levels for MSI packages.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Condition" href="http://msdn.microsoft.com/library/aa368014.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Condition" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The condition expression to be evaluated at install time. When true the Feature level is set to the Value.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="Integer" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Allows modifying the level of a Feature based on the result of the condition.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="IsolateComponent">
+    <xs:annotation>
+      <xs:documentation>
+                Shared Component to be privately replicated in folder of parent Component
+            </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="IsolateComponent" href="http://msdn.microsoft.com/library/aa369730.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Shared" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Shared Component for this application Component.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ReserveCost">
+    <xs:annotation>
+      <xs:documentation>
+        Disk cost to reserve in a folder for running locally and/or from source.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="ReserveCost" href="http://msdn.microsoft.com/library/aa371226.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>A primary key that uniquely identifies this ReserveCost entry.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Directory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Adds the amount of disk space specified in RunFromSource or RunLocal to the volume cost of the device containing the directory.
+            If this attribute is not set, it will default to the directory of parent component.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Subdirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute defines one or more directories below the directory referenced by the Directory attribute
+            to add cost to.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RunFromSource" type="Integer" use="required">
+        <xs:annotation>
+          <xs:documentation>The number of bytes of disk space to reserve if the component is installed to run from source.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RunLocal" type="Integer" use="required">
+        <xs:annotation>
+          <xs:documentation>The number of bytes of disk space to reserve if the component is installed to run locally.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Component">
+    <xs:annotation>
+      <xs:documentation>Component for parent Directory</xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="ComponentRef" />
+        <xse:msiRef table="Component" href="http://msdn.microsoft.com/library/aa368007.aspx" />
+        <xse:msiRef table="Condition" href="http://msdn.microsoft.com/library/aa368014.aspx" />
+        <xse:msiRef table="Directory" href="http://msdn.microsoft.com/library/aa368295.aspx" />
+        <xse:howtoRef href="files_and_registry/add_a_file.html">How To: Add a file to your installer</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="AppId" />
+        <xs:element ref="Category" />
+        <xs:element ref="Class" />
+        <xs:element ref="CopyFile" />
+        <xs:element ref="CreateFolder" />
+        <xs:element ref="Environment" />
+        <xs:element ref="Extension" />
+        <xs:element ref="File" />
+        <xs:element ref="IniFile" />
+        <xs:element ref="Interface" />
+        <xs:element ref="IsolateComponent" />
+        <xs:element ref="ODBCDataSource" />
+        <xs:element ref="ODBCDriver" />
+        <xs:element ref="ODBCTranslator" />
+        <xs:element ref="ProgId" />
+        <xs:element ref="Provides" />
+        <xs:element ref="RegistryKey" />
+        <xs:element ref="RegistryValue" />
+        <xs:element ref="RemoveFile" />
+        <xs:element ref="RemoveFolder" />
+        <xs:element ref="RemoveRegistryKey" />
+        <xs:element ref="RemoveRegistryValue" />
+        <xs:element ref="ReserveCost" />
+        <xs:element ref="ServiceControl" />
+        <xs:element ref="ServiceConfig" />
+        <xs:element ref="ServiceConfigFailureActions" />
+        <xs:element ref="ServiceInstall" />
+        <xs:element ref="Shortcut" />
+        <xs:element ref="SymbolPath" />
+        <xs:element ref="TypeLib" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Component identifier; this is the primary key for identifying components. If omitted,
+            the compiler defaults the identifier to the identifier of the resource that is the
+            explicit keypath of the component (for example, a child File element with KeyPath
+            attribute with value 'yes').
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ComPlusFlags" type="Integer">
+        <xs:annotation>
+          <xs:documentation>
+            Set this attribute to create a ComPlus entry. The value should be the export flags used
+            during the generation of the .msi file. For more information see the COM+ documentation
+            in the Platform SDK.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Condition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The condition expression to be evaluated at install time. When false the Component will not be installed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DisableRegistryReflection" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Set this attribute to 'yes' in order to disable registry reflection on all existing and
+            new registry keys affected by this component.
+            When set to 'yes', the Windows Installer calls the RegDisableReflectionKey on each key
+            being accessed by the component.
+            This bit is available with Windows Installer version 4.0 and is ignored on 32-bit systems.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Directory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Sets the Directory of the Component. If this element is nested under a Directory element,
+            this value defaults to the value of the parent Directory/@Id.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DiskId" type="DiskIdType">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute provides a default DiskId attribute for all child File elements. Specifying
+            the DiskId on a Component element will override any DiskId attributes set by parent Directory
+            or DirectoryRef elements. See the File element's DiskId attribute for more information about
+            the purpose of the DiskId.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Feature" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Identifies a feature to which this component belongs, as a shorthand for a child
+            ComponentRef element of the Feature element. The value of this attribute should
+            correspond to the Id attribute of a Feature element authored elsewhere. Note that
+            a single component can belong to multiple features but this attribute allows you
+            to specify only a single feature.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Guid" type="ComponentGuid">
+        <xs:annotation>
+          <xs:documentation>
+            This value should be a guid that uniquely identifies this component's contents, language, platform, and version.
+            If omitted, the default value is '*' which indicates that the linker should generate a stable guid.
+            Generatable guids are supported only for components with a single file as the component's keypath
+            or no files and a registry value as the keypath.
+            It's also possible to set the value to an empty string to specify an unmanaged component.
+            Unmanaged components are a security vulnerability because the component cannot be removed or repaired
+            by Windows Installer (it is essentially an unpatchable, permanent component). Therefore, a guid should
+            always be specified for any component which contains resources that may need to be patched in the future.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="KeyPath" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            If this attribute's value is set to 'yes', then the Directory of this Component is used
+            as the KeyPath. To set a Registry value or File as the KeyPath of a component, set the
+            KeyPath attribute to 'yes' on one of those child elements. If KeyPath is not set to 'yes' for the
+            Component or for a child Registry value or File, WiX will look at the child elements under the
+            Component in sequential order and try to automatically select one of them as a key path. Allowing
+            WiX to automatically select a key path can be dangerous because adding or removing child elements
+            under the Component can inadvertantly cause the key path to change, which can lead to
+            installation problems.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Location">
+        <xs:annotation>
+          <xs:documentation>
+            Optional value that specifies the location that the component can be run from.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="local">
+              <xs:annotation>
+                <xs:documentation>
+                  Prevents the component from running from the source or the network (this is the default behavior if this attribute is not set).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="source">
+              <xs:annotation>
+                <xs:documentation>
+                  Enforces that the component can only be run from the source (it cannot be run from the user's computer).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="either">
+              <xs:annotation>
+                <xs:documentation>
+                  Allows the component to run from source or locally.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="MultiInstance" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            If this attribute is set to 'yes', a new Component/@Guid will be generated for each
+            instance transform. Ensure that all of the resources contained in a multi-instance
+            Component will be installed to different paths based on the instance Property; otherwise,
+            the Component Rules will be violated.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="NeverOverwrite" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            If this attribute is set to 'yes', the installer does not install or reinstall the
+            component if a key path file or a key path registry entry for the component already
+            exists. The application does register itself as a client of the component. Use this
+            flag only for components that are being registered by the Registry table. Do not use
+            this flag for components registered by the AppId, Class, Extension, ProgId, MIME, and
+            Verb tables.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Permanent" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            If this attribute is set to 'yes', the installer does not remove the component during
+            an uninstall. The installer registers an extra system client for the component in
+            the Windows Installer registry settings (which basically just means that at least one
+            product is always referencing this component). Note that this option differs from the
+            behavior of not setting a guid because although the component is permanent, it is still
+            patchable (because Windows Installer still tracks it), it's just not uninstallable.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Shared" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            If this attribute's value is set to 'yes', enables advanced patching semantics for
+            Components that are shared across multiple MSI packages. Specifically, the Windows Installer
+            will cache the shared files to improve patch uninstall. This functionality is available
+            in Windows Installer 4.5 and later.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SharedDllRefCount" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            If this attribute's value is set to 'yes', the installer increments the reference count
+            in the shared DLL registry of the component's key file. If this bit is not set, the
+            installer increments the reference count only if the reference count already exists.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Subdirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute defines one or more directories below the directory referenced by the Directory attribute or parent
+            Directory reference where the Component will be installed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Transitive" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            If this attribute is set to 'yes', the installer reevaluates the value of the statement
+            in the Condition upon a reinstall. If the value was previously False and has changed to
+            True, the installer installs the component. If the value was previously True and has
+            changed to False, the installer removes the component even if the component has other
+            products as clients.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UninstallWhenSuperseded" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            If this attribute is set to 'yes', the installer will uninstall the Component's files
+            and registry keys when it is superseded by a patch. This functionality is available in
+            Windows Installer 4.5 and later.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Bitness" type="BitnessTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Overrides the default Component bitness. Only 64-bit Components can install to 64-bit locations such
+            as `ProgramFiles64Folder` and the 64-bit registry. The value `always64` will force the Component
+            bitness to be 64-bit and cannot be included in 32-bit packages.
+            Simliarly, the value `always32` will force the Component bitness to 32-bit and can be included in
+            32-bit or 64-bit packages.
+            The default value is `default` where the Component will be installed using the
+            same bitness as the package.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ComponentGroup">
+    <xs:annotation>
+      <xs:documentation>
+        Groups together multiple components to be used in other locations.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="ComponentGroupRef" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Component" />
+        <xs:element ref="ComponentGroupRef" />
+        <xs:element ref="ComponentRef" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier for the ComponentGroup.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Directory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Sets the default directory identifier for child Component elements.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Subdirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute defines one or more directories below the directory referenced by the Directory attribute or parent
+            Directory reference where the contained Components will be installed.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Source" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Used to set the default file system source for child Component elements. For more information, see
+            <html:a href="~/howtos/general/specifying_source_files.html">Specifying source files</html:a>.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ComponentGroupRef">
+    <xs:annotation>
+      <xs:documentation>Create a reference to a ComponentGroup in another Fragment.</xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="ComponentGroup" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the ComponentGroup to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Primary" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Set this attribute to 'yes' in order to make the parent feature of this component
+            the primary feature for this component. Components may belong to multiple features.
+            By designating a feature as the primary feature of a component, you ensure that
+            whenever a component is selected for install-on-demand (IOD), the primary feature
+            will be the one to install it. This attribute should only be set if a component
+            actually nests under multiple features. If a component nests under only one feature,
+            that feature is the primary feature for the component. You cannot set more than one
+            feature as the primary feature of a given component.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="All">
+    <xs:annotation>
+      <xs:documentation>Used only for PatchFamilies to include all changes between the baseline and upgraded packages in a patch.</xs:documentation>
+      <xs:appinfo>
+        <xse:remarks>
+          <html:p>Warning: this is intended for testing purposes only. Shipping a patch with all changes negates the benefits of using patch families for including only specific changes.</html:p>
+          <html:p>Because changing the ProductCode is not supported in a patch, the ProductCode property is automatically removed from the transform.</html:p>
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="BinaryRef">
+    <xs:annotation>
+      <xs:documentation>Used only for PatchFamilies to include only a binary table entry in a patch.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the Binary element to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+                    Extensibility point in the WiX XML Schema. Schema extensions can register additional
+                    attributes at this point in the schema.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="IconRef">
+    <xs:annotation>
+      <xs:documentation>Used only for PatchFamilies to include only a icon table entry in a patch.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the Icon element to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+                    Extensibility point in the WiX XML Schema. Schema extensions can register additional
+                    attributes at this point in the schema.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ComponentRef">
+    <xs:annotation>
+      <xs:documentation>Create a reference to a Feature element in another Fragment.</xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Component" />
+        <xse:howtoRef href="files_and_registry/add_a_file.html">How To: Add a file to your installer</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the Component element to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Primary" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+                    Set this attribute to 'yes' in order to make the parent feature of this component
+                    the primary feature for this component. Components may belong to multiple features.
+                    By designating a feature as the primary feature of a component, you ensure that
+                    whenever a component is selected for install-on-demand (IOD), the primary feature
+                    will be the one to install it. This attribute should only be set if a component
+                    actually nests under multiple features. If a component nests under only one feature,
+                    that feature is the primary feature for the component. You cannot set more than one
+                    feature as the primary feature of a given component.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+                    Extensibility point in the WiX XML Schema. Schema extensions can register additional
+                    attributes at this point in the schema.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Merge">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="MergeRef" />
+        <xse:howtoRef href="redistributables_and_install_checks/install_vcredist.html">How To: Install the Visual C++ Redistributable with your installer</xse:howtoRef>
+      </xs:appinfo>
+      <xs:documentation>Merge directive to bring in a merge module that will be redirected to the parent directory.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="ConfigurationData">
+          <xs:annotation>
+            <xs:documentation>Data to use as input to a configurable merge module.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The unique identifier for the Merge element in the source code. Referenced by the MergeRef/@Id.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DiskId" type="DiskIdType">
+        <xs:annotation>
+          <xs:documentation>The value of this attribute should correspond to the Id attribute of a
+                    Media element authored elsewhere. By creating this connection between the merge module and Media
+                    element, you set the packaging options to the values specified in the Media
+                    element (values such as compression level, cab embedding, etc...).</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="FileCompression" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Specifies if the files in the merge module should be compressed.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Language" type="LocalizableInteger" use="required">
+        <xs:annotation>
+          <xs:documentation>Specifies the decimal LCID or localization token for the language to merge the Module in as.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Path to the source location of the merge module.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MergeRef">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Merge" />
+        <xse:howtoRef href="redistributables_and_install_checks/install_vcredist.html">How To: Install the Visual C++ Redistributable with your installer</xse:howtoRef>
+      </xs:appinfo>
+      <xs:documentation>Merge reference to connect a Merge Module to parent Feature</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The unique identifier for the Merge element to be referenced.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Primary" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Specifies whether the feature containing this MergeRef is the primary feature for advertising the merge module's components.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+                    Extensibility point in the WiX XML Schema. Schema extensions can register additional
+                    attributes at this point in the schema.
+                </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ConfigurationData">
+    <xs:annotation>
+      <xs:documentation>Data to use as input to a configurable merge module.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Name" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Name of the item in the ModuleConfiguration table.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Value to be passed to configurable merge module.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Directory">
+    <xs:annotation>
+      <xs:documentation>Directory layout for the product. Also specifies the mappings between source and target directories.</xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="DirectoryRef" />
+        <xse:msiRef table="Directory" href="http://msdn.microsoft.com/library/aa368295.aspx" />
+        <xse:howtoRef href="files_and_registry/add_a_file.html">How To: Add a file to your installer</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Component" />
+        <xs:element ref="Directory" />
+        <xs:element ref="Merge" />
+        <xs:element ref="SymbolPath" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            An optional identifier for the directory. If one is not specified,
+            a private identifier will be generated.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ComponentGuidGenerationSeed" type="Guid">
+        <xs:annotation>
+          <xs:documentation>
+            The Component Guid Generation Seed is a guid that must be used when a Component with the generate guid directive ("*")
+            is not rooted in a standard Windows Installer directory (for example, ProgramFilesFolder or CommonFilesFolder).
+            It is recommended that this attribute be avoided and that developers install their Components under standard
+            directories with unique names instead (for example, "ProgramFilesFolder\Company Name Product Name Version"). It is
+            important to note that once a directory is assigned a Component Guid Generation Seed the value must not change until
+            (and must be changed when) the path to that directory, including itself and all parent directories, changes.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DiskId" type="DiskIdType">
+        <xs:annotation>
+          <xs:documentation>
+            Sets the default disk identifier for the files contained in this directory.
+            This attribute's value may be overridden by a child Component, Directory,
+            Merge or File element. See the File or Merge elements' DiskId attribute for
+            more information.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="FileSource" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Used to set the file system source for this directory's child elements. For more information, see <html:a href="~/howtos/general/specifying_source_files.html">Specifying source files</html:a>.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The name of the directory.
+
+            Do not specify this attribute if this directory represents
+            the same directory as the parent (see the Windows Installer SDK's
+            <html:a href="http://msdn.microsoft.com/library/Aa368295.aspx">Directory table</html:a>
+            topic for more information about the "." operator).
+
+            This attribute's value may either a short or long directory name. If a short directory
+            name is specified, the ShortName attribute may not be specified. If this value is a long
+            directory name, the ShortName attribute may be omitted to
+            allow WiX to attempt to generate a unique short directory name.
+            However, if this name collides with another directory or you wish to manually specify
+            the short directory name, then the ShortName attribute may be specified.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ShortName" type="ShortFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+            The short name of the directory in 8.3 format.
+            This attribute should only be set if there is a conflict between generated short directory names
+            or the user wants to manually specify the short directory name.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ShortSourceName" type="ShortFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+            The short name of the directory on the source media in 8.3 format.
+            This attribute should only be set if there is a conflict between generated short directory names
+            or the user wants to manually specify the short source directory name.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceName" type="LongFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+            The name of the directory on the source media.
+            If this attribute is not specified, Windows Installer will default to the Name attribute.
+
+            In prior versions of the WiX toolset, this attribute specified the short source directory name.
+            This attribute's value may now be either a short or long directory name.
+            If a short directory name is specified, the ShortSourceName attribute may not be specified.
+            If a long directory name is specified, the LongSource attribute may not be specified.
+            Also, if this value is a long directory name, the ShortSourceName attribute may be omitted to
+            allow WiX to attempt to generate a unique short directory name.
+            However, if this name collides with another directory or you wish to manually specify
+            the short directory name, then the ShortSourceName attribute may be specified.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="DirectoryRef">
+    <xs:annotation>
+      <xs:documentation>Create a reference to a Directory element in another Fragment.</xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Directory" />
+        <xse:howtoRef href="files_and_registry/add_a_file.html">How To: Add a file to your installer</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Component" />
+        <xs:element ref="Directory" />
+        <xs:element ref="Merge" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the Directory element to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DiskId" type="DiskIdType">
+        <xs:annotation>
+          <xs:documentation>
+            Sets the default disk identifier for the files contained in this directory.
+            This attribute's value may be overridden by a child Component, Directory,
+            Merge or File element. See the File or Merge elements' DiskId attribute for
+            more information.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="FileSource" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Used to set the file system source for this DirectoryRef's child elements. For more information, see <html:a href="~/howtos/general/specifying_source_files.html">Specifying source files</html:a>.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SoftwareTag">
+    <xs:annotation>
+      <xs:documentation>
+        This extension implements the ISO/IEC 19770-2:2015 specification. A SWID tag file
+        will be generated an inserted into the Package or Bundle.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Name" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>
+              Name to use in the filename for the software id tag. By default the filename
+              uses the Bundle/@Name or Package/@Name. If the bundle name or package name contains
+              invalid filename characters such as ":" or "?", use this attribute to provide
+              a valid filename.
+            </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Regid" type="xs:string" use="required">
+        <xs:annotation>
+            <xs:documentation>
+              The regid for the software manufacturer. A regid is a URI simplified for the common
+              case. Namely, if the scheme is "http://", it can be removed. Additionally, the domain
+              should be minimized as much as possible (for example, remove "www." prefix if unnecessary).
+
+              For example, the WiX toolset regid is "wixtoolset.org".
+            </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="InstallDirectory" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>
+              A reference to an existing Directory/@Id where the software is installed. The SWID tag file will be installed in a "swidtag" folder
+              under that directory as per the specification. This attribute is required on a SoftwareTag element found under a Package element.
+            </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="InstallPath" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>
+              The path where the software is installed. The SWID tag file will be installed in a "swidtag" folder.
+              This is a formatted attribute so it is possible to use Variables as the InstallPath by setting
+              the value to, for example, "[ProgramFilesFolder]CompanyName\Product Name". This attribute is required
+              on a SoftwareTag element found under a Bundle element.
+            </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Feature" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>
+              Optional attribute to explicitly set the Feature when defining the software id tag
+              in a Package. By default the software id tag will always be installed by a top-level hidden feature.
+              It is recommended to <html:strong>not</html:strong> set this attribute.
+            </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Bitness" type="BitnessTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute facilitates the installation of packages that install both 32-bit and 64-bit files. Set this attribute to 'always32'
+            force the software id tag to a 32-bit location (such as "ProgramFilesFolder") or 'always64' to force the tag to be installed to
+            a 64-bit location (such as "ProgramFiles64Folder").
+
+            The default value is `default` where the tag will be installed to the directory that matches the
+            same bitness as the package.
+
+            This attribute is only allowed on a SoftwareTag element found under a Package element.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="StandardDirectory">
+    <xs:annotation>
+      <xs:documentation>References a standard Windows Installer directory, such as ProgramFilesFolder.</xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Directory" />
+        <xse:howtoRef href="files_and_registry/add_a_file.html">How To: Add a file to your installer</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Component" />
+        <xs:element ref="Directory" />
+        <xs:element ref="Merge" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="StandardDirectoryTypeUnion" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the standard directory to include in the package.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="UpgradeVersion">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="Upgrade" href="https://learn.microsoft.com/en-us/windows/win32/msi/upgrade-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Minimum" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Specifies the lower bound on the range of product versions to be detected by FindRelatedProducts.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Maximum" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Specifies the upper boundary of the range of product versions detected by FindRelatedProducts.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Language" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Specifies the set of languages detected by FindRelatedProducts. Enter a list of numeric language identifiers (LANGID) separated by commas (,). Leave this value null to specify all languages. Set ExcludeLanguages to "yes" in order detect all languages, excluding the languages listed in this value.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RemoveFeatures" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The installer sets the REMOVE property to features specified in this column. The features to be removed can be determined at run time. The Formatted string entered in this field must evaluate to a comma-delimited list of feature names. For example: [Feature1],[Feature2],[Feature3]. No features are removed if the field contains formatted text that evaluates to an empty string. The installer sets REMOVE=ALL only if the Remove field is empty.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Property" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>When the FindRelatedProducts action detects a related product installed on the system, it appends the product code to the property specified in this field. Windows Installer documentation for the <html:a href="https://learn.microsoft.com/en-us/windows/win32/msi/upgrade-table">Upgrade table</html:a> states that the property specified in this field must be a public property and must be added to the <html:a href="http://msdn.microsoft.com/library/aa371571.aspx">SecureCustomProperties</html:a> property. WiX automatically appends the property specified in this field to the SecureCustomProperties property when creating an MSI. Each UpgradeVersion must have a unique Property value. After the FindRelatedProducts action is run, the value of this property is a list of product codes, separated by semicolons (;), detected on the system.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MigrateFeatures" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set to "yes" to migrate feature states from upgraded products by enabling the logic in the MigrateFeatureStates action.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OnlyDetect" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set to "yes" to detect products and applications but do not uninstall.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreRemoveFailure" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set to "yes" to continue installation upon failure to remove a product or application.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IncludeMinimum" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set to "no" to make the range of versions detected exclude the value specified in Minimum. This attribute is "yes" by default.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IncludeMaximum" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set to "yes" to make the range of versions detected include the value specified in Maximum.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ExcludeLanguages" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set to "yes" to detect all languages, excluding the languages listed in the Language attribute.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Upgrade">
+    <xs:annotation>
+      <xs:documentation>
+        Upgrade info for a particular UpgradeCode
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Upgrade" href="https://learn.microsoft.com/en-us/windows/win32/msi/upgrade-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="UpgradeVersion" />
+        <xs:element ref="Property">
+          <xs:annotation>
+            <xs:documentation>
+              Nesting a Property element under an Upgrade element has been deprecated.
+              Please nest Property elements in any of the other supported locations.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="Id" type="Guid" use="required">
+        <xs:annotation>
+          <xs:documentation>This value specifies the upgrade code for the products that are to be detected by the FindRelatedProducts action.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Feature">
+    <xs:annotation>
+      <xs:documentation>
+        A feature for the Feature table. Features are the smallest installable unit. See msi.chm for more
+        detailed information on the myriad installation options for a feature.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="FeatureRef" />
+        <xse:msiRef table="Feature" href="https://learn.microsoft.com/en-us/windows/win32/msi/feature-table" />
+        <xse:howtoRef href="files_and_registry/add_a_file.html">How To: Add a file to your installer</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Component" />
+        <xs:element ref="ComponentGroupRef" />
+        <xs:element ref="ComponentRef" />
+        <xs:element ref="Level" />
+        <xs:element ref="Feature" />
+        <xs:element ref="FeatureGroupRef" />
+        <xs:element ref="FeatureRef" />
+        <xs:element ref="MergeRef" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Unique identifier of the feature. The id must be shorter than 38 characters.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="AllowAbsent" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute determines if a user will have the option to set a feature to absent in the user interface.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="AllowAdvertise" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute determines the possible advertise states for this feature. The default is 'yes'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ConfigurableDirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Specify the Id of a Directory that can be configured by the user at installation time. This identifier
+            must be a public property and therefore completely uppercase.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Description" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Longer string of text describing the feature. This localizable string is displayed by the
+            Text Control of the Selection Dialog.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Display" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Determines the initial display of this feature in the feature tree.
+            This attribute's value should be one of the following:
+
+            - `collapse`: Initially shows the feature collapsed. This is the default value.
+            - `expand`: Initially shows the feature expanded.
+            - `hidden`: Prevents the feature from displaying in the user interface.
+            - an explicit integer value: For advanced users only, it is possible to directly set the integer value of the display value that will appear in the Feature row.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="InstallDefault">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute determines the default install/run location of a feature. This attribute cannot be specified
+            if the value of the FollowParent attribute is 'yes' since that would ask the installer to force this feature
+            to follow the parent installation state and simultaneously favor a particular installation state just for this feature.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="followParent">
+              <xs:annotation>
+                <xs:documentation>
+                  Forces the feature to follow the same installation state as its parent feature.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="local">
+              <xs:annotation>
+                <xs:documentation>
+                  Favors installing this feature locally by setting the msidbFeatureAttributesFavorLocal attribute.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="source">
+              <xs:annotation>
+                <xs:documentation>
+                  Favors running this feature from source by setting the msidbFeatureAttributesFavorSource attribute.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Level" type="Integer">
+        <xs:annotation>
+          <xs:documentation>
+            Sets the install level of this feature. A value of 0 will disable the feature. This value
+            can be modified at install time using the Level element as a child of the Feature.
+            The default value is "1".
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Title" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Short string of text identifying the feature. This string is listed as an item by the
+            SelectionTree control of the Selection Dialog.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="TypicalDefault">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute determines the default advertise state of the feature.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="advertise">
+              <xs:annotation>
+                <xs:documentation>
+                  Sets the feature to be advertised by setting the msidbFeatureAttributesFavorAdvertise attribute.
+                  This value cannot be set if the value of the AllowAdvertise attribute is 'no' since that would ask the installer to
+                  disallow the advertised state for this feature while at the same time favoring it.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="install">
+              <xs:annotation>
+                <xs:documentation>
+                  Sets the feature to the default non-advertised installation option.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="FeatureGroup">
+    <xs:annotation>
+      <xs:documentation>
+        Groups together multiple components, features, and merges to be used in other locations.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="FeatureGroupRef" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Component" />
+        <xs:element ref="ComponentGroupRef" />
+        <xs:element ref="ComponentRef" />
+        <xs:element ref="Feature" />
+        <xs:element ref="FeatureGroupRef" />
+        <xs:element ref="FeatureRef" />
+        <xs:element ref="MergeRef" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier for the FeatureGroup.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="FeatureGroupRef">
+    <xs:annotation>
+      <xs:documentation>Create a reference to a FeatureGroup in another Fragment.</xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="FeatureGroup" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the FeatureGroup to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreParent" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Normally feature group references that end up nested under a parent element create a
+            connection to that parent. This behavior is undesirable when trying to simply reference
+            to a FeatureGroup in a different Fragment. Specify 'yes' to have this feature group
+            reference not create a connection to its parent. The default is 'no'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Primary" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Set this attribute to 'yes' in order to make the parent feature of this group
+            the primary feature for any components and merges contained in the group.
+            Features may belong to multiple features. By designating a feature as the
+            primary feature of a component or merge, you ensure that whenever a component is
+            selected for install-on-demand (IOD), the primary feature will be the one to install
+            it. This attribute should only be set if a component actually nests under multiple
+            features. If a component nests under only one feature, that feature is the primary
+            feature for the component. You cannot set more than one feature as the primary
+            feature of a given component.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="FeatureRef">
+    <xs:annotation>
+      <xs:documentation>Create a reference to a Feature element in another Fragment.</xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Feature" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Component" />
+        <xs:element ref="ComponentGroupRef" />
+        <xs:element ref="ComponentRef" />
+        <xs:element ref="Feature" />
+        <xs:element ref="FeatureRef" />
+        <xs:element ref="FeatureGroup" />
+        <xs:element ref="FeatureGroupRef" />
+        <xs:element ref="MergeRef" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the Feature element to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreParent" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Normally feature references that are nested under a parent element create a connection to that
+            parent. This behavior is undesirable when trying to simply reference a Feature in a different
+            Fragment. Specify 'yes' to have this feature reference not create a connection to its parent.
+            The default is 'no'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Media">
+    <xs:annotation>
+      <xs:documentation>Media element describes a disk that makes up the source media for the installation.</xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Media" href="http://msdn.microsoft.com/library/aa369801.aspx" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:element ref="DigitalSignature" minOccurs="0" />
+          <xs:element ref="PatchBaseline" minOccurs="0" maxOccurs="unbounded" />
+          <xs:element ref="SymbolPath" />
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="Id" type="DiskIdType" use="required">
+        <xs:annotation>
+          <xs:documentation>Disk identifier for Media table. This number must be equal to or greater than 1.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Cabinet" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The name of the cabinet if some or all of the files stored on the media are in a cabinet file. If no cabinets are used, this attribute must not be set.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="CompressionLevel" type="CompressionLevelTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Indicates the compression level for the Media's cabinet. This attribute can
+            only be used in conjunction with the Cabinet attribute. The default is 'medium'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DiskPrompt" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The disk name, which is usually the visible text printed on the disk. This localizable text is used to prompt the user when this disk needs to be inserted. This value will be used in the "[1]" of the DiskPrompt Property. Using this attribute will require you to define a DiskPrompt Property.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="EmbedCab" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Instructs the binder to embed the cabinet in the product if 'yes'. This attribute can only be specified in conjunction with the Cabinet attribute.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Layout" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                        This attribute specifies the root directory for the uncompressed files that
+                        are a part of this Media element. By default, the src will be the output
+                        directory for the final image. The default value ensures the binder generates
+                        an installable image. If a relative path is specified in the src attribute,
+                        the value will be appended to the image's output directory. If an absolute
+                        path is provided, that path will be used without modification. The latter two
+                        options are provided to ease the layout of an image onto multiple medias (CDs/DVDs).
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="VolumeLabel" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                        The label attributed to the volume. This is the volume label returned
+                        by the GetVolumeInformation function. If the SourceDir property refers
+                        to a removable (floppy or CD-ROM) volume, then this volume label is
+                        used to verify that the proper disk is in the drive before attempting
+                        to install files. The entry in this column must match the volume label
+                        of the physical media.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Source" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                        Optional property that identifies the source of the embedded cabinet.
+                        If a cabinet is specified for a patch, this property should be defined
+                        and unique to each patch so that the embedded cabinet containing patched
+                        and new files can be located in the patch package. If the cabinet is not
+                        embedded - this is not typical - the cabinet can be found in the directory
+                        referenced in this column. If empty, the external cabinet must be located
+                        in the SourceDir directory.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MediaTemplate">
+    <xs:annotation>
+      <xs:documentation>
+                MediaTeplate element describes information to automatically assign files to cabinets.
+                A maximumum number of cabinets created is 999.
+            </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="CabinetTemplate" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                        Templated name of the cabinet if some or all of the files stored on the media are in
+                        a cabinet file. This name must begin with either a letter or an underscore, contain
+                        maximum of five characters and {0} in the cabinet name part and must end three character extension.
+                        The default is cab{0}.cab.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="CompressionLevel" type="CompressionLevelTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Indicates the compression level for the Media's cabinet. This attribute can
+            only be used in conjunction with the Cabinet attribute. The default is 'mszip'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DiskPrompt" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                        The disk name, which is usually the visible text printed on the disk. This localizable text is used
+                        to prompt the user when this disk needs to be inserted. This value will be used in the "[1]" of the
+                        DiskPrompt Property. Using this attribute will require you to define a DiskPrompt Property.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="EmbedCab" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Instructs the binder to embed the cabinets in the product if 'yes'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="VolumeLabel" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+                        The label attributed to the volume. This is the volume label returned
+                        by the GetVolumeInformation function. If the SourceDir property refers
+                        to a removable (floppy or CD-ROM) volume, then this volume label is
+                        used to verify that the proper disk is in the drive before attempting
+                        to install files. The entry in this column must match the volume label
+                        of the physical media.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MaximumUncompressedMediaSize" type="xs:int">
+        <xs:annotation>
+          <xs:documentation>
+                        Size of uncompressed files in each cabinet, in megabytes. WIX_MUMS environment variable
+                        can be used to override this value. Default value is 200 MB.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MaximumCabinetSizeForLargeFileSplitting" type="xs:int">
+        <xs:annotation>
+          <xs:documentation>
+                        Maximum size of cabinet files in megabytes for large files. This attribute is used for packaging
+                        files that are larger than MaximumUncompressedMediaSize into smaller cabinets. If cabinet size
+                        exceed this value, then setting this attribute will cause the file to be split into multiple
+                        cabinets of this maximum size. For simply controlling cabinet size without file splitting use
+                        MaximumUncompressedMediaSize attribute. Setting this attribute will disable smart cabbing feature
+                        for this Fragment / Package. Setting WIX_MCSLFS environment variable can be used to override this
+                        value. Minimum allowed value of this attribute is 20 MB. Maximum allowed value and the Default
+                        value of this attribute is 2048 MB (2 GB).
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CustomAction">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Custom" />
+        <xse:seeAlso ref="CustomActionRef" />
+        <xse:msiRef table="CustomAction" href="https://learn.microsoft.com/en-us/windows/win32/msi/customaction-table" />
+      </xs:appinfo>
+      <xs:documentation>
+        Specifies a custom action to be added to the MSI CustomAction table. Various combinations of the attributes for this element
+        correspond to different custom action types. For more information about custom actions see the
+        <html:a href="https://learn.microsoft.com/en-us/windows/win32/msi/summary-list-of-all-custom-action-types">
+        Custom Action Types</html:a> topic on MSDN.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The identifier of the custom action.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <!-- CustomAction Source specification, sets source Attribute bits -->
+      <xs:attribute name="BinaryRef" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute is a reference to a Binary element with matching Id attribute. That binary stream contains
+            the custom action for use during install. The custom action will not be installed into a target directory. This attribute is
+            typically used with the DllEntry attribute to specify the custom action DLL to use for a type 1 custom action, with the ExeCommand
+            attribute to specify a type 17 custom action that runs an embedded executable, or with the VBScriptCall or JScriptCall attributes
+            to specify a type 5 or 6 custom action.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="FileRef" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies a reference to a File element with matching Id attribute that
+            will execute the custom action code in the file after the file is installed. This
+            attribute is typically used with the ExeCommand attribute to specify a type 18 custom action
+            that runs an installed executable, with the DllEntry attribute to specify an installed custom
+            action DLL to use for a type 17 custom action, or with the VBScriptCall or JScriptCall
+            attributes to specify a type 21 or 22 custom action.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Property" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies a reference to a Property element with matching Id attribute that specifies the Property
+            to be used or updated on execution of this custom action. This attribute is
+            typically used with the Value attribute to create a type 51 custom action that parses
+            the text in Value and places it into the specified Property. This attribute is also used with
+            the ExeCommand attribute to create a type 50 custom action that uses the value of the
+            given property to specify the path to the executable. Type 51 custom actions are often useful to
+            pass values to a deferred custom action.
+            See <html:a href="https://learn.microsoft.com/en-us/windows/win32/msi/obtaining-context-information-for-deferred-execution-custom-actions">
+            Obtaining Context Information for Deferred Execution Custom Actions</html:a> for more information.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Directory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies a reference to a Directory element with matching Id attribute containing a directory path.
+            This attribute is typically used with the ExeCommand attribute to specify the source executable for a type 34
+            custom action, or with the Value attribute to specify a formatted string to place in the specified Directory
+            table entry in a type 35 custom action.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Subdirectory" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute defines one or more directories below the directory referenced by the Directory attribute.
+            This attribute is optional but can only be specified when the Directory attribute is also specified.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <!-- CustomAction Target specification, sets target Attribute bits -->
+      <xs:attribute name="DllEntry" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies the name of a function in a custom action to execute.
+            This attribute is used with the BinaryRef attribute to create a type 1 custom
+            action, or with the FileRef attribute to create a type 17 custom action.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ExeCommand" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies the command line parameters to supply to an externally
+            run executable. This attribute is typically used with the BinaryRef attribute for a type 2 custom action,
+            the FileRef attribute for a type 18 custom action, the Property attribute for a type 50 custom action,
+            or the Directory attribute for a type 34 custom action that specify the executable to run.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="JScriptCall" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies the name of the JScript function to execute in a script. The script must be
+            provided in a Binary element identified by the BinaryRef attribute described above. In other words, this
+            attribute must be specified in conjunction with the BinaryRef attribute.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="VBScriptCall" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies the name of the VBScript Subroutine to execute in a script. The script must be
+            provided in a Binary element identified by the BinaryRef attribute described above. In other words, this
+            attribute must be specified in conjunction with the BinaryRef attribute.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Script">
+        <xs:annotation>
+          <xs:documentation>
+            Creates a type 37 or 38 custom action. Specify a path to the script to be embedded in the package in the
+            `ScriptSourceFile` attribute.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="jscript" />
+            <xs:enumeration value="vbscript" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="ScriptSourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Path to the external file containing the script code. Can be used only with the Script attribute.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SuppressModularization" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Use to suppress modularization of this custom action name in merge modules.
+            This should only be necessary for table-driven custom actions because the
+            table name which they interact with cannot be modularized, so there can only
+            be one instance of the table.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies a string value to use in the custom action. This attribute
+            must be used with the Property attribute to set the property as part of a
+            type 51 custom action or with the Directory attribute to set a directory path in that
+            table in a type 35 custom action. The value can be a literal value or derived from a
+            Property element using the <html:a href="https://learn.microsoft.com/en-us/windows/win32/msi/formatted">Formatted</html:a>
+            syntax.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Error" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies an index in the MSI Error table to use as an error message for a
+            type 19 custom action that displays the error message and aborts a product's installation.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <!-- Other CustomAction type attributes -->
+      <xs:attribute name="Return">
+        <xs:annotation>
+          <xs:documentation>
+            Set this attribute to set the return behavior of the custom action.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="asyncNoWait">
+              <xs:annotation>
+                <xs:documentation>
+                  Indicates that the custom action will run asyncronously and execution may continue after the installer terminates.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="asyncWait">
+              <xs:annotation>
+                <xs:documentation>
+                  Indicates that the custom action will run asynchronously but the installer will wait for the return code at sequence end.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="check">
+              <xs:annotation>
+                <xs:documentation>
+                  Indicates that the custom action will run synchronously and the return code will be checked for success. This is the default.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="ignore">
+              <xs:annotation>
+                <xs:documentation>
+                  Indicates that the custom action will run synchronously and the return code will not be checked.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Execute">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute indicates the scheduling of the custom action.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="commit">
+              <xs:annotation>
+                <xs:documentation>
+                  Indicates that the custom action will run after successful completion of the installation script (at the end of the installation).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="deferred">
+              <xs:annotation>
+                <xs:documentation>
+                  Indicates that the custom action runs in-script (possibly with elevated privileges).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="firstSequence">
+              <xs:annotation>
+                <xs:documentation>
+                  Indicates that the custom action will only run in the first sequence that runs it.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="immediate">
+              <xs:annotation>
+                <xs:documentation>
+                  Indicates that the custom action will run during normal processing time with user privileges. This is the default.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="oncePerProcess">
+              <xs:annotation>
+                <xs:documentation>
+                  Indicates that the custom action will only run in the first sequence that runs it in the same process.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="rollback">
+              <xs:annotation>
+                <xs:documentation>
+                  Indicates that a custom action will run in the rollback sequence when a failure
+                  occurs during installation, usually to undo changes made by a deferred custom action.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="secondSequence">
+              <xs:annotation>
+                <xs:documentation>
+                  Indicates that a custom action should be run a second time if it was previously run in an earlier sequence.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Impersonate" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies whether the Windows Installer, which executes as LocalSystem,
+            should impersonate the user context of the installing user when executing this custom action.
+            Typically the value should be 'yes', except when the custom action needs elevated privileges
+            to apply changes to the machine.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PatchUninstall" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies that the Windows Installer, execute the custom action only when
+            a patch is being uninstalled. These custom actions should also be conditioned using the
+            MSIPATCHREMOVE property to ensure proper down level (less than Windows Installer 4.5)
+            behavior.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Bitness" type="BitnessTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Valid only when used with the Script, VBScriptCall, and JScriptCall attributes.
+            Overrides the default scripting host for script custom actions. The value `always64` will force the
+            script to run in the 64-bit scripting host. Simliarly, the value `always32` will force the script
+            to run in the 64-bit scripting host.
+            The default value is `default` where the script will be run in the scripting host that matches the
+            same bitness as the package.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="TerminalServerAware" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies controls whether the custom action will impersonate the
+            installing user during per-machine installs on Terminal Server machines.
+            Deferred execution custom actions that do not specify this attribute, or explicitly set it 'no',
+            will run with no user impersonation on Terminal Server machines during
+            per-machine installations. This attribute is only applicable when installing on the
+            Windows Server 2003 family.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="HideTarget" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Ensures the installer does not log the CustomActionData for the deferred custom action.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CustomActionRef">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="CustomAction" />
+      </xs:appinfo>
+      <xs:documentation>
+        This will cause the entire contents of the Fragment containing the referenced CustomAction to be
+        included in the installer database.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the CustomAction to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SetDirectory">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Custom" />
+        <xse:seeAlso ref="CustomActionRef" />
+        <xse:seeAlso ref="InstallUISequence" />
+        <xse:seeAlso ref="InstallExecuteSequence" />
+        <xse:msiRef table="CustomAction" href="https://learn.microsoft.com/en-us/windows/win32/msi/customaction-table" />
+      </xs:appinfo>
+      <xs:documentation>
+        Sets a Directory to a particular value. This is accomplished by creating a Type 51 custom action that is appropriately scheduled in
+        the InstallUISequence and InstallExecuteSequence.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Action" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            By default the action is "Set" + Id attribute's value. This optional attribute can override the action name in the case
+            where multiple SetDirectory elements target the same Id (probably with mutually exclusive conditions).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Condition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The condition that determines whether the Directory is set. If the condition evaluates to false, the SetDirectory is skipped.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies a reference to a Directory element with matching Id attribute. The path of the Directory will be set to
+            the Value attribute.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Sequence" type="SequenceType">
+        <xs:annotation>
+          <xs:documentation>
+            Controls which sequences the Directory assignment is sequenced in.
+            For 'execute', the assignment is scheduled in the InstallExecuteSequence.
+            For 'ui', the assignment is scheduled in the InstallUISequence.
+            For 'first', the assignment is scheduled in the InstallUISequence or the InstallExecuteSequence if the InstallUISequence is skipped at install time.
+            For 'both', the assignment is scheduled in both the InstallUISequence and the InstallExecuteSequence.
+            The default is 'both'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies a string value to assign to the Directory. The value can be a literal value or derived from a
+            Property element using the <html:a href="https://learn.microsoft.com/en-us/windows/win32/msi/formatted">Formatted</html:a>
+            syntax.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="SetProperty">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Custom" />
+        <xse:seeAlso ref="CustomActionRef" />
+        <xse:seeAlso ref="InstallUISequence" />
+        <xse:seeAlso ref="InstallExecuteSequence" />
+        <xse:msiRef table="CustomAction" href="https://learn.microsoft.com/en-us/windows/win32/msi/customaction-table" />
+      </xs:appinfo>
+      <xs:documentation>
+        Sets a Property to a particular value. This is accomplished by creating a Type 51 custom action that is appropriately scheduled in
+        the InstallUISequence and InstallExecuteSequence.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Action" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            By default the action is "Set" + Id attribute's value. This optional attribute can override the action name in the case
+            where multiple SetProperty elements target the same Id (probably with mutually exclusive conditions).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="After" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The name of the standard or custom action after which this action should be performed. Mutually exclusive with
+            the Before attribute. A Before or After attribute is required when setting a Property.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Before" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The name of the standard or custom action before which this action should be performed. Mutually exclusive with the After attribute. A Before or After attribute is required when setting a Property.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Condition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The condition that determines whether the Property is set. If the condition evaluates to false, the Set is skipped.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies the Property to set to the Value.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Sequence" type="SequenceType">
+        <xs:annotation>
+          <xs:documentation>
+            Controls which sequences the Property assignment is sequenced in.
+            For 'execute', the assignment is scheduled in the InstallExecuteSequence.
+            For 'ui', the assignment is scheduled in the InstallUISequence.
+            For 'first', the assignment is scheduled in the InstallUISequence or the InstallExecuteSequence if the InstallUISequence is skipped at install time.
+            For 'both', the assignment is scheduled in both the InstallUISequence and the InstallExecuteSequence.
+            The default is 'both'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute specifies a string value to assign to the Property. The value can be a literal value or derived from a
+            Property element using the <html:a href="https://learn.microsoft.com/en-us/windows/win32/msi/formatted">Formatted</html:a>
+            syntax.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="PatchFamilyRef">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="PatchFamily" />
+      </xs:appinfo>
+      <xs:documentation>
+        This will cause the entire contents of the Fragment containing the referenced PatchFamily to be
+        used in the process of creating a patch.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the PatchFamily to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProductCode" type="Guid">
+        <xs:annotation>
+          <xs:documentation>Specifies the ProductCode of the product that this family applies to.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- - - - - - - - - - - Sequence Table Definitions - - - - - - - - - - - - - - -->
+  <xs:element name="ValidateProductID" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="ValidateProductID" href="http://msdn.microsoft.com/library/aa372475.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Sets the ProductID property to the full product identifier. This action must be sequenced before the user interface wizard in the InstallUISequence table and before the RegisterUser action in the InstallExecuteSequence table. If the product identifier has already been validated successfully, the ValidateProductID action does nothing. The ValidateProductID action always returns a success, whether or not the product identifier is valid, so that the product identifier can be entered on the command line the first time the product is run. The product identifier can be validated without having the user reenter this information by setting the PIDKEY property on the command line or by using a transform. The display of the dialog box requesting the user to enter the product identifier can then be made conditional upon the presence of the ProductID property, which is set when the PIDKEY property is validated. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CostInitialize" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="FileCost" />
+        <xse:seeAlso ref="CostFinalize" />
+        <xse:msiRef action="CostInitialize" href="http://msdn.microsoft.com/library/aa368048.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Initiates the internal installation costing process. Any standard or custom actions that affect costing should be sequenced before the CostInitialize action. Call the FileCost action immediately following the CostInitialize action. Then call the CostFinalize action following the CostInitialize action to make all final cost calculations available to the installer through the Component table. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="FileCost" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="CostInitialize" />
+        <xse:seeAlso ref="CostFinalize" />
+        <xse:msiRef action="FileCost" href="http://msdn.microsoft.com/library/aa368589.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Initiates dynamic costing of standard installation actions. Any standard or custom actions that affect costing should sequenced before the CostInitialize action. Call the FileCost action immediately following the CostInitialize action. Then call the CostFinalize action following the FileCost action to make all final cost calculations available to the installer through the Component table. The CostInitialize action must be executed before the FileCost action. The installer then determines the disk-space cost of every file in the File table, on a per-component basis, taking both volume clustering and the presence of existing files that may need to be overwritten into account. All actions that consume or release disk space are also considered. If an existing file is found, a file version check is performed to determine whether the new file actually needs to be installed or not. If the existing file is of an equal or greater version number, the existing file is not overwritten and no disk-space cost is incurred. In all cases, the installer uses the results of version number checking to set the installation state of each file. The FileCost action initializes cost calculation with the installer. Actual dynamic costing does not occur until the CostFinalize action is executed. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="IsolateComponents" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="IsolateComponent" />
+        <xse:msiRef action="IsolateComponents" href="http://msdn.microsoft.com/library/aa369561.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Installs a copy of a component (commonly a shared DLL) into a private location for use by a specific application (typically an .exe). This isolates the application from other copies of the component that may be installed to a shared location on the computer. The action refers to each record of the IsolatedComponent table and associates the files of the component listed in the Component_Shared field with the component listed in the Component_Application field. The installer installs the files of Component_Shared into the same directory as Component_Application. The installer generates a file in this directory, zero bytes in length, having the short filename name of the key file for Component_Application (typically this is the same file name as the .exe) appended with .local. The IsolatedComponent action does not affect the installation of Component_Application. Uninstalling Component_Application also removes the Component_Shared files and the .local file from the directory. The IsolateComponents action can be used only in the InstallUISequence table and the InstallExecuteSequence table. This action must come after the CostInitialize action and before the CostFinalize action. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CostFinalize" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="CostInitialize" />
+        <xse:seeAlso ref="FileCost" />
+        <xse:msiRef action="CostFinalize" href="http://msdn.microsoft.com/library/aa368048.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Ends the internal installation costing process begun by the CostInitialize action. Any standard or custom actions that affect costing should be sequenced before the CostInitialize action. Call the FileCost action immediately following the CostInitialize action and then call the CostFinalize action to make all final cost calculations available to the installer through the Component table. The CostFinalize action must be executed before starting any user interface sequence which allows the user to view or modify Feature table selections or directories. The CostFinalize action queries the Condition table to determine which features are scheduled to be installed. Costing is done for each component in the Component table. The CostFinalize action also verifies that all the target directories are writable before allowing the installation to continue. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="SetODBCFolders" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="SetODBCFolders" href="http://msdn.microsoft.com/library/aa371691.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Checks for existing ODBC drivers and sets the target directory for each new driver to the location of an existing driver. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="MigrateFeatureStates" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="MigrateFeatureStates" href="http://msdn.microsoft.com/library/aa370034.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Used for upgrading or installing over an existing application. Reads feature states from existing application and sets these feature states for the pending installation. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="ExecuteAction" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="ExecuteAction" href="http://msdn.microsoft.com/library/aa368565.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Initiates the execution sequence. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="InstallValidate" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="InstallValidate" href="http://msdn.microsoft.com/library/aa369546.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Verifies that all costed volumes have enough space for the installation. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="InstallInitialize" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="InstallFinalize" />
+        <xse:msiRef action="InstallInitialize" href="http://msdn.microsoft.com/library/aa369535.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Marks the beginning of a sequence of actions that change the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="AllocateRegistrySpace" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="AllocateRegistrySpace" href="http://msdn.microsoft.com/library/aa367554.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Ensures the needed amount of space exists in the registry. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="ProcessComponents" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="ProcessComponents" href="http://msdn.microsoft.com/library/aa370853.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Registers and unregisters components, their key paths, and the component clients. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UnpublishComponents" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="UnpublishComponents" href="http://msdn.microsoft.com/library/aa372106.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Manages the unadvertisement of components listed in the PublishComponent table. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="MsiUnpublishAssemblies" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="MsiUnpublishAssemblies" href="http://msdn.microsoft.com/library/aa370500.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Manages the unadvertisement of CLR and Win32 assemblies that are being removed. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UnpublishFeatures" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="UnpublishFeatures" href="http://msdn.microsoft.com/library/aa372107.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Removes selection-state and feature-component mapping information from the registry. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="StopServices" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="StopServices" href="http://msdn.microsoft.com/library/aa372028.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Stops system services. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="DeleteServices" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="DeleteServices" href="http://msdn.microsoft.com/library/aa368270.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Stops a service and removes its registration from the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UnregisterComPlus" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="UnregisterComPlus" href="http://msdn.microsoft.com/library/aa372109.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Removes COM+ applications from the registry. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="SelfUnregModules" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="SelfUnregModules" href="http://msdn.microsoft.com/library/aa371610.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Unregisters all modules listed in the SelfReg table that are scheduled to be uninstalled. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UnregisterTypeLibraries" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="UnregisterTypeLibraries" href="http://msdn.microsoft.com/library/aa372357.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Unregisters type libraries from the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RemoveODBC" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RemoveODBC" href="http://msdn.microsoft.com/library/aa371206.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Removes the data sources, translators, and drivers listed for removal during the installation. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UnregisterFonts" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="UnregisterFonts" href="http://msdn.microsoft.com/library/aa372112.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Removes registration information about installed fonts from the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RemoveRegistryValues" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RemoveRegistryValues" href="http://msdn.microsoft.com/library/aa371207.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Removes a registry value that has been authored into the registry table if the associated component was installed locally or as run from source, and is now set to be uninstalled. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UnregisterClassInfo" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="UnregisterClassInfo" href="http://msdn.microsoft.com/library/aa372108.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Manages the removal of COM class information from the system registry. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UnregisterExtensionInfo" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="UnregisterExtensionInfo" href="http://msdn.microsoft.com/library/aa372110.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Manages the removal of extension-related information from the system registry. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UnregisterProgIdInfo" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="UnregisterProgIdInfo" href="http://msdn.microsoft.com/library/aa372114.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Manages the unregistration of OLE ProgId information with the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="UnregisterMIMEInfo" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="UnregisterMIMEInfo" href="http://msdn.microsoft.com/library/aa372113.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Unregisters MIME-related registry information from the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RemoveIniValues" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RemoveIniValues" href="http://msdn.microsoft.com/library/aa371205.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Removes .ini file information specified for removal in the RemoveIniFile table if the component is set to be installed locally or run from source. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RemoveShortcuts" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RemoveShortcuts" href="http://msdn.microsoft.com/library/aa371209.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Manages the removal of an advertised shortcut whose feature is selected for uninstallation or a nonadvertised shortcut whose component is selected for uninstallation. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RemoveEnvironmentStrings" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RemoveEnvironmentStrings" href="http://msdn.microsoft.com/library/aa371196.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Modifies the values of environment variables. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RemoveDuplicateFiles" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RemoveDuplicateFiles" href="http://msdn.microsoft.com/library/aa371195.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Deletes files installed by the DuplicateFiles action. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RemoveFiles" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RemoveFiles" href="http://msdn.microsoft.com/library/aa371199.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Removes files previously installed by the InstallFiles action. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RemoveFolders" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RemoveFolders" href="http://msdn.microsoft.com/library/aa371202.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Removes any folders linked to components set to be removed or run from source. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CreateFolders" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="CreateFolders" href="http://msdn.microsoft.com/library/aa368052.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Creates empty folders for components that are set to be installed. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="MoveFiles" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="MoveFile" href="http://msdn.microsoft.com/library/aa370055.aspx" />
+        <xse:msiRef action="MoveFiles" href="http://msdn.microsoft.com/library/aa370054.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Locates existing files on the system and moves or copies those files to a new location. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="InstallAdminPackage" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="InstallAdminPackage" href="http://msdn.microsoft.com/library/aa369287.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Copies the product database to the administrative installation point. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="InstallFiles" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="InstallFiles" href="http://msdn.microsoft.com/library/aa369503.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Copies files specified in the File table from the source directory to the destination directory. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="DuplicateFiles" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="DuplicateFiles" href="http://msdn.microsoft.com/library/aa368334.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Duplicates files installed by the InstallFiles action. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="PatchFiles" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="PatchFiles" href="http://msdn.microsoft.com/library/aa370577.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Queries the Patch table to determine which patches are to be applied. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="BindImage" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="BindImage" href="http://msdn.microsoft.com/library/aa367828.aspx" />
+        <xse:msiRef action="BindImage" href="http://msdn.microsoft.com/library/aa367827.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Binds each executable or DLL that must be bound to the DLLs imported by it. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CreateShortcuts" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="CreateShortcuts" href="http://msdn.microsoft.com/library/aa368054.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Manages the creation of shortcuts. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RegisterClassInfo" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RegisterClassInfo" href="http://msdn.microsoft.com/library/aa371154.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Manages the registration of COM class information with the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RegisterExtensionInfo" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RegisterExtensionInfo" href="http://msdn.microsoft.com/library/aa371156.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Manages the registration of extension related information with the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RegisterProgIdInfo" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RegisterProgIdInfo" href="http://msdn.microsoft.com/library/aa371164.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Manages the registration of OLE ProgId information with the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RegisterMIMEInfo" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RegisterMIMEInfo" href="http://msdn.microsoft.com/library/aa371160.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Registers MIME-related registry information with the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="WriteRegistryValues" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="WriteRegistryValues" href="http://msdn.microsoft.com/library/aa372891.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Sets up an application's registry information. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="WriteIniValues" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="WriteIniValues" href="http://msdn.microsoft.com/library/aa372884.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Writes the .ini file information that the application needs written to its .ini files. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="WriteEnvironmentStrings" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="WriteEnvironmentStrings" href="http://msdn.microsoft.com/library/aa372883.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Modifies the values of environment variables. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RegisterFonts" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RegisterFonts" href="http://msdn.microsoft.com/library/aa371158.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Registers installed fonts with the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="InstallODBC" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="InstallODBC" href="http://msdn.microsoft.com/library/aa369538.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Installs the drivers, translators, and data sources in the ODBCDriver table, ODBCTranslator table, and ODBCDataSource table. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RegisterTypeLibraries" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RegisterTypeLibraries" href="http://msdn.microsoft.com/library/aa371165.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Registers type libraries with the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="SelfRegModules" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="SelfRegModules" href="http://msdn.microsoft.com/library/aa371607.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Processes all modules listed in the SelfReg table and registers all installed modules with the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RegisterComPlus" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RegisterComPlus" href="http://msdn.microsoft.com/library/aa371155.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Registers COM+ applications. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="InstallServices" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="InstallServices" href="http://msdn.microsoft.com/library/aa369540.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Registers a service for the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="StartServices" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="StartServices" href="http://msdn.microsoft.com/library/aa372026.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Starts system services. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RegisterUser" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RegisterUser" href="http://msdn.microsoft.com/library/aa371166.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Registers the user information with the installer to identify the user of a product. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RegisterProduct" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RegisterProduct" href="http://msdn.microsoft.com/library/aa371162.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Registers the product information with the installer. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="PublishComponents" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="PublishComponents" href="http://msdn.microsoft.com/library/aa370918.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Manages the advertisement of the components from the PublishComponent table. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="MsiPublishAssemblies" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="MsiPublishAssemblies" href="http://msdn.microsoft.com/library/aa370359.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Manages the advertisement of CLR and Win32 assemblies. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="PublishFeatures" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="PublishFeatures" href="http://msdn.microsoft.com/library/aa370923.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Writes each feature's state into the system registry. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="PublishProduct" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="PublishProduct" href="http://msdn.microsoft.com/library/aa370932.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Manages the advertisement of the product information with the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="InstallFinalize" type="ActionSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="InstallInitialize" />
+        <xse:msiRef action="InstallFinalize" href="http://msdn.microsoft.com/library/aa369505.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Marks the end of a sequence of actions that change the system. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="AppSearch" type="ActionModuleSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="ComponentSearch" />
+        <xse:seeAlso ref="FileSearch" />
+        <xse:seeAlso ref="IniFileSearch" />
+        <xse:seeAlso ref="RegistrySearch" />
+        <xse:msiRef table="AppSearch" href="http://msdn.microsoft.com/library/aa367579.aspx" />
+        <xse:msiRef action="AppSearch" href="http://msdn.microsoft.com/library/aa367578.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Uses file signatures to search for existing versions of products. The AppSearch action may use this information to determine where upgrades are to be installed. The AppSearch action can also be used to set a property to the existing value of an registry or .ini file entry. AppSearch should be authored into the InstallUISequence table and InstallExecuteSequence table. The installer prevents The AppSearch action from running in the InstallExecuteSequence sequence if the action has already run in InstallUISequence sequence. The AppSearch action searches for file signatures using the CompLocator table first, the RegLocator table next, then the IniLocator table, and finally the DrLocator table. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="CCPSearch" type="ActionModuleSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="RMCCPSearch" />
+        <xse:seeAlso ref="ComplianceCheck" />
+        <xse:msiRef action="CCPSearch" href="http://msdn.microsoft.com/library/aa367845.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Uses file signatures to validate that qualifying products are installed on a system before an upgrade installation is performed. The CCPSearch action should be authored into the InstallUISequence table and InstallExecuteSequence table. The installer prevents the CCPSearch action from running in the InstallExecuteSequence sequence if the action has already run in InstallUISequence sequence. The CCPSearch action must come before the RMCCPSearch action. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RMCCPSearch" type="ActionModuleSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="CCPSearch" />
+        <xse:seeAlso ref="ComplianceCheck" />
+        <xse:msiRef action="RMCCPSearch" href="http://msdn.microsoft.com/library/aa371364.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Uses file signatures to validate that qualifying products are installed on a system before an upgrade installation is performed. The RMCCPSearch action should be authored into the InstallUISequence table and InstallExecuteSequence table. The installer prevents RMCCPSearch from running in the InstallExecuteSequence sequence if the action has already run in InstallUISequence sequence. The RMCCPSearch action requires the CCP_DRIVE property to be set to the root path on the removable volume that has the installation for any of the qualifying products. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="LaunchConditions" type="ActionModuleSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Launch" />
+        <xse:msiRef action="LaunchConditions" href="http://msdn.microsoft.com/library/aa369751.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Queries the LaunchCondition table and evaluates each conditional statement recorded there. If any of these conditional statements fail, an error message is displayed to the user and the installation is terminated. The LaunchConditions action is optional. This action is normally the first in the sequence, but the AppSearch Action may be sequenced before the LaunchConditions action. If there are launch conditions that do not apply to all installation modes, the appropriate installation mode property should be used in a conditional expression in the appropriate sequence table. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="FindRelatedProducts" type="ActionModuleSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Upgrade" />
+        <xse:msiRef action="FindRelatedProducts" href="http://msdn.microsoft.com/library/aa368600.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Runs through each record of the Upgrade table in sequence and compares the upgrade code, product version, and language in each row to products installed on the system. When FindRelatedProducts detects a correspondence between the upgrade information and an installed product, it appends the product code to the property specified in the ActionProperty column of the UpgradeTable. The FindRelatedProducts action only runs the first time the product is installed. The FindRelatedProducts action does not run during maintenance mode or uninstallation. FindRelatedProducts should be authored into the InstallUISequence table and InstallExecuteSequence tables. The installer prevents FindRelatedProducts from running in InstallExecuteSequence if the action has already run in InstallUISequence. The FindRelatedProducts action must come before the MigrateFeatureStates action and the RemoveExistingProducts action. The condition for this action may be specified in the element's inner text.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="InstallExecute" type="ActionModuleSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="InstallExecute" href="http://msdn.microsoft.com/library/aa369502.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Runs a script containing all operations spooled since either the start of the installation or the last InstallExecute action, or InstallExecuteAgain action. Special actions don't have a built-in sequence number and thus must appear relative to another action. The suggested way to do this is by using the Before or After attribute. InstallExecute and InstallExecuteAgain can optionally appear anywhere between InstallInitialize and InstallFinalize.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="InstallExecuteAgain" type="ActionModuleSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="InstallExecuteAgain" href="http://msdn.microsoft.com/library/aa369497.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Runs a script containing all operations spooled since either the start of the installation or the last InstallExecute action, or InstallExecuteAgain action. Should only be used after InstallExecute. Special actions don't have a built-in sequence number and thus must appear relative to another action. The suggested way to do this is by using the Before or After attribute. InstallExecute and InstallExecuteAgain can optionally appear anywhere between InstallInitialize and InstallFinalize.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="DisableRollback" type="ActionModuleSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="DisableRollback" href="http://msdn.microsoft.com/library/aa368308.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Disables rollback for the remainder of the installation. Special actions don't have a built-in sequence number and thus must appear relative to another action. The suggested way to do this is by using the Before or After attribute. InstallExecute and InstallExecuteAgain can optionally appear anywhere between InstallInitialize and InstallFinalize.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="RemoveExistingProducts" type="ActionModuleSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="RemoveExistingProducts" href="http://msdn.microsoft.com/library/aa371197.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Goes through the product codes listed in the ActionProperty column of the Upgrade table and removes the products in sequence. Special actions don't have a built-in sequence number and thus must appear relative to another action. The suggested way to do this is by using the Before or After attribute. InstallExecute and InstallExecuteAgain can optionally appear anywhere between InstallInitialize and InstallFinalize.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="ScheduleReboot" type="ActionModuleSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="ScheduleReboot" href="http://msdn.microsoft.com/library/aa371527.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Prompts the user to restart the system at the end of installation. Special actions don't have a built-in sequence number and thus must appear relative to another action. The suggested way to do this is by using the Before or After attribute. InstallExecute and InstallExecuteAgain can optionally appear anywhere between InstallInitialize and InstallFinalize.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="ForceReboot" type="ActionModuleSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="ForceReboot" href="http://msdn.microsoft.com/library/aa368607.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Prompts the user for a restart of the system during the installation. Special actions don't have a built-in sequence number and thus must appear relative to another action. The suggested way to do this is by using the Before or After attribute. InstallExecute and InstallExecuteAgain can optionally appear anywhere between InstallInitialize and InstallFinalize.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <xs:element name="ResolveSource" type="ActionModuleSequenceType">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef action="ResolveSource" href="http://msdn.microsoft.com/library/aa371232.aspx" />
+      </xs:appinfo>
+      <xs:documentation>Determines the location of the source and sets the SourceDir property if the source has not been resolved yet. Special actions don't have a built-in sequence number and thus must appear relative to another action. The suggested way to do this is by using the Before or After attribute. InstallExecute and InstallExecuteAgain can optionally appear anywhere between InstallInitialize and InstallFinalize.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <!-- CustomActions and Dialogs of course aren't built in and must be specified relative to another action -->
+  <xs:element name="Custom">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="CustomAction" />
+      </xs:appinfo>
+      <xs:documentation>Use to sequence a custom action.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:annotation>
+        <xs:documentation>Text node specifies the condition of the action.</xs:documentation>
+      </xs:annotation>
+      <xs:attribute name="Action" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The CustomAction to which the Custom element applies.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Condition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Optional condition that determines whether the action should be executed.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OnExit" type="ExitType">
+        <xs:annotation>
+          <xs:documentation>Mutually exclusive with Before, After, and Sequence attributes</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Before" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The name of the standard or custom action before which this action should be performed. Mutually exclusive with OnExit, After, and Sequence attributes</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="After" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The name of the standard or custom action after which this action should be performed. Mutually exclusive with Before, OnExit, and Sequence attributes</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Overridable" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>If "yes", the sequencing of this action may be overridden by sequencing elsewhere.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Sequence" type="Integer">
+        <xs:annotation>
+          <xs:documentation>The sequence number for this action. It is recommended to use one of the other mutually exclusive attributes: OnExit, After, and Before.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Show">
+    <xs:complexType>
+      <xs:attribute name="Dialog" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Reference to dialog to show.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Condition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Optional condition that determines whether the dialog should be displayed.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="OnExit" type="ExitType">
+        <xs:annotation>
+          <xs:documentation>Show the dialog Mutually exclusive with Before, After, and Sequence attributes.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Before" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Show the dialog before the specified action. Mutually exclusive with OnExit, After, and Sequence attributes.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="After" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Show the dialog after the specified action. Mutually exclusive with OnExit, Before, and Sequence attributes.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Overridable" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            If "yes", the sequencing of this dialog may be overridden by sequencing elsewhere. The default is "no".
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Sequence" type="Integer">
+        <xs:annotation>
+          <xs:documentation>Show the dialog at the specified sequence. It is recommended to use one of the other mutually exclusive attributes: OnExit, After, and Before.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- standard sequence table compositions -->
+  <xs:element name="InstallUISequence">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="InstallUISequence" href="https://docs.microsoft.com/en-us/windows/win32/msi/installuisequence-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Custom" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Use to sequence a custom action.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="Show" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Displays a Dialog.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ScheduleReboot" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Prompts the user to restart the system at the end of installation. Not fixed sequence.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="LaunchConditions" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Queries the LaunchCondition table and evaluates each conditional statement recorded there.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="FindRelatedProducts" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Runs through each record of the Upgrade table in sequence and compares the upgrade code, product version, and language in each row to products installed on the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="AppSearch" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Uses file signatures to search for existing versions of products.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="CCPSearch" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Uses file signatures to validate that qualifying products are installed on a system before an upgrade installation is performed.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RMCCPSearch" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Uses file signatures to validate that qualifying products are installed on a system before an upgrade installation is performed.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ValidateProductID">
+          <xs:annotation>
+            <xs:documentation>Sets the ProductID property to the full product identifier.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="CostInitialize">
+          <xs:annotation>
+            <xs:documentation>Initiates the internal installation costing process.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="FileCost">
+          <xs:annotation>
+            <xs:documentation>Initiates dynamic costing of standard installation actions.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="IsolateComponents">
+          <xs:annotation>
+            <xs:documentation>Installs a copy of a component (commonly a shared DLL) into a private location for use by a specific application (typically an .exe).</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ResolveSource" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Determines the location of the source and sets the SourceDir property if the source has not been resolved yet.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="CostFinalize">
+          <xs:annotation>
+            <xs:documentation>Ends the internal installation costing process begun by the CostInitialize action.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="MigrateFeatureStates">
+          <xs:annotation>
+            <xs:documentation>Used for upgrading or installing over an existing application.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ExecuteAction" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Initiates the execution sequence.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="InstallExecuteSequence">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="InstallExecuteSequence" href="https://docs.microsoft.com/en-us/windows/win32/msi/installexecutesequence-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Custom" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Use to sequence a custom action.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ScheduleReboot" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Prompts the user to restart the system at the end of installation. Not fixed sequence.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ForceReboot" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Prompts the user for a restart of the system during the installation. Not fixed sequence.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ResolveSource" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Determines the location of the source and sets the SourceDir property if the source has not been resolved yet. Not fixed sequence.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="LaunchConditions" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Queries the LaunchCondition table and evaluates each conditional statement recorded there.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="FindRelatedProducts" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Runs through each record of the Upgrade table in sequence and compares the upgrade code, product version, and language in each row to products installed on the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="AppSearch" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Uses file signatures to search for existing versions of products.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="CCPSearch">
+          <xs:annotation>
+            <xs:documentation>Uses file signatures to validate that qualifying products are installed on a system before an upgrade installation is performed.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RMCCPSearch">
+          <xs:annotation>
+            <xs:documentation>Uses file signatures to validate that qualifying products are installed on a system before an upgrade installation is performed.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ValidateProductID">
+          <xs:annotation>
+            <xs:documentation>Sets the ProductID property to the full product identifier.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="CostInitialize">
+          <xs:annotation>
+            <xs:documentation>Initiates the internal installation costing process.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="FileCost">
+          <xs:annotation>
+            <xs:documentation>Initiates dynamic costing of standard installation actions.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="IsolateComponents">
+          <xs:annotation>
+            <xs:documentation>Installs a copy of a component (commonly a shared DLL) into a private location for use by a specific application (typically an .exe).</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="CostFinalize">
+          <xs:annotation>
+            <xs:documentation>Ends the internal installation costing process begun by the CostInitialize action.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="SetODBCFolders">
+          <xs:annotation>
+            <xs:documentation>Checks for existing ODBC drivers and sets the target directory for each new driver to the location of an existing driver.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="MigrateFeatureStates">
+          <xs:annotation>
+            <xs:documentation>Used for upgrading or installing over an existing application.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallValidate">
+          <xs:annotation>
+            <xs:documentation>Verifies that all costed volumes have enough space for the installation.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallInitialize">
+          <xs:annotation>
+            <xs:documentation>Marks the beginning of a sequence of actions that change the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="AllocateRegistrySpace" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Ensures the needed amount of space exists in the registry.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ProcessComponents">
+          <xs:annotation>
+            <xs:documentation>Registers and unregisters components, their key paths, and the component clients.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="UnpublishComponents" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Manages the unadvertisement of components listed in the PublishComponent table.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="UnpublishFeatures" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Removes selection-state and feature-component mapping information from the registry.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="StopServices">
+          <xs:annotation>
+            <xs:documentation>Stops system services.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="DeleteServices">
+          <xs:annotation>
+            <xs:documentation>Stops a service and removes its registration from the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="UnregisterComPlus">
+          <xs:annotation>
+            <xs:documentation>Removes COM+ applications from the registry.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="SelfUnregModules" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Unregisters all modules listed in the SelfReg table that are scheduled to be uninstalled.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="UnregisterTypeLibraries" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Unregisters type libraries from the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RemoveODBC">
+          <xs:annotation>
+            <xs:documentation>Removes the data sources, translators, and drivers listed for removal during the installation.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="UnregisterFonts">
+          <xs:annotation>
+            <xs:documentation>Removes registration information about installed fonts from the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RemoveRegistryValues" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Removes a registry value that has been authored into the registry table if the associated component was installed locally or as run from source, and is now set to be uninstalled.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="UnregisterClassInfo" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Manages the removal of COM class information from the system registry.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="UnregisterExtensionInfo">
+          <xs:annotation>
+            <xs:documentation>Manages the removal of extension-related information from the system registry.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="UnregisterProgIdInfo" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Manages the unregistration of OLE ProgId information with the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="UnregisterMIMEInfo">
+          <xs:annotation>
+            <xs:documentation>Unregisters MIME-related registry information from the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RemoveIniValues">
+          <xs:annotation>
+            <xs:documentation>Removes .ini file information specified for removal in the RemoveIniFile table if the component is set to be installed locally or run from source.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RemoveShortcuts" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Manages the removal of an advertised shortcut whose feature is selected for uninstallation or a nonadvertised shortcut whose component is selected for uninstallation.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RemoveEnvironmentStrings">
+          <xs:annotation>
+            <xs:documentation>Modifies the values of environment variables.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RemoveDuplicateFiles">
+          <xs:annotation>
+            <xs:documentation>Deletes files installed by the DuplicateFiles action.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RemoveFiles" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Removes files previously installed by the InstallFiles action.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RemoveFolders" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Removes any folders linked to components set to be removed or run from source.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="CreateFolders" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Creates empty folders for components that are set to be installed.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="MoveFiles">
+          <xs:annotation>
+            <xs:documentation>Locates existing files on the system and moves or copies those files to a new location.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallFiles" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Copies files specified in the File table from the source directory to the destination directory.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="DuplicateFiles">
+          <xs:annotation>
+            <xs:documentation>Duplicates files installed by the InstallFiles action.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="PatchFiles">
+          <xs:annotation>
+            <xs:documentation>Queries the Patch table to determine which patches are to be applied.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="BindImage" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Binds each executable or DLL that must be bound to the DLLs imported by it.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="CreateShortcuts" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Manages the creation of shortcuts.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RegisterClassInfo" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Manages the registration of COM class information with the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RegisterExtensionInfo">
+          <xs:annotation>
+            <xs:documentation>Manages the registration of extension related information with the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RegisterProgIdInfo" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Manages the registration of OLE ProgId information with the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RegisterMIMEInfo">
+          <xs:annotation>
+            <xs:documentation>Registers MIME-related registry information with the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="WriteRegistryValues" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Sets up an application's registry information.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="WriteIniValues">
+          <xs:annotation>
+            <xs:documentation>Writes the .ini file information that the application needs written to its .ini files.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="WriteEnvironmentStrings">
+          <xs:annotation>
+            <xs:documentation>Modifies the values of environment variables.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RegisterFonts">
+          <xs:annotation>
+            <xs:documentation>Registers installed fonts with the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallODBC">
+          <xs:annotation>
+            <xs:documentation>Installs the drivers, translators, and data sources in the ODBCDriver table, ODBCTranslator table, and ODBCDataSource table.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RegisterTypeLibraries" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Registers type libraries with the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="SelfRegModules" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Processes all modules listed in the SelfReg table and registers all installed modules with the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RegisterComPlus">
+          <xs:annotation>
+            <xs:documentation>Registers COM+ applications.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallServices">
+          <xs:annotation>
+            <xs:documentation>Registers a service for the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="StartServices">
+          <xs:annotation>
+            <xs:documentation>Starts system services.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RegisterUser" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Registers the user information with the installer to identify the user of a product.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RegisterProduct" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Registers the product information with the installer.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="PublishComponents" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Manages the advertisement of the components from the PublishComponent table.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="PublishFeatures" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Writes each feature's state into the system registry.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="PublishProduct" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Manages the advertisement of the product information with the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallFinalize">
+          <xs:annotation>
+            <xs:documentation>Marks the end of a sequence of actions that change the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RemoveExistingProducts">
+          <xs:annotation>
+            <xs:documentation>Goes through the product codes listed in the ActionProperty column of the Upgrade table and removes the products in sequence.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="DisableRollback" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Disables rollback for the remainder of the installation.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallExecute" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Runs a script containing all operations spooled since either the start of the installation or the last InstallExecute action, or InstallExecuteAgain action.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallExecuteAgain" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Runs a script containing all operations spooled since either the start of the installation or the last InstallExecute action, or InstallExecuteAgain action.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="MsiPublishAssemblies">
+          <xs:annotation>
+            <xs:documentation>Manages the advertisement of CLR and Win32 assemblies.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="MsiUnpublishAssemblies">
+          <xs:annotation>
+            <xs:documentation>Manages the unadvertisement of CLR and Win32 assemblies that are being removed.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AdminUISequence">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="AdminUISequence" href="https://docs.microsoft.com/en-us/windows/win32/msi/adminuisequence-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Custom" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Use to sequence a custom action.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="Show" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element ref="CostInitialize">
+          <xs:annotation>
+            <xs:documentation>Initiates the internal installation costing process.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="FileCost">
+          <xs:annotation>
+            <xs:documentation>Initiates dynamic costing of standard installation actions.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="CostFinalize">
+          <xs:annotation>
+            <xs:documentation>Ends the internal installation costing process begun by the CostInitialize action.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ExecuteAction">
+          <xs:annotation>
+            <xs:documentation>Initiates the execution sequence.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallValidate">
+          <xs:annotation>
+            <xs:documentation>Verifies that all costed volumes have enough space for the installation.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallInitialize">
+          <xs:annotation>
+            <xs:documentation>Marks the beginning of a sequence of actions that change the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallAdminPackage">
+          <xs:annotation>
+            <xs:documentation>Copies the product database to the administrative installation point.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallFiles">
+          <xs:annotation>
+            <xs:documentation>Copies files specified in the File table from the source directory to the destination directory.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallFinalize">
+          <xs:annotation>
+            <xs:documentation>Marks the end of a sequence of actions that change the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="LaunchConditions">
+          <xs:annotation>
+            <xs:documentation>Queries the LaunchCondition table and evaluates each conditional statement recorded there.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AdminExecuteSequence">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="AdminExecuteSequence" href="https://docs.microsoft.com/en-us/windows/win32/msi/adminexecutesequence-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Custom" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Use to sequence a custom action.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="CostInitialize">
+          <xs:annotation>
+            <xs:documentation>Initiates the internal installation costing process.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="FileCost">
+          <xs:annotation>
+            <xs:documentation>Initiates dynamic costing of standard installation actions.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="CostFinalize">
+          <xs:annotation>
+            <xs:documentation>Ends the internal installation costing process begun by the CostInitialize action.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallValidate">
+          <xs:annotation>
+            <xs:documentation>Verifies that all costed volumes have enough space for the installation.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallInitialize">
+          <xs:annotation>
+            <xs:documentation>Marks the beginning of a sequence of actions that change the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallAdminPackage">
+          <xs:annotation>
+            <xs:documentation>Copies the product database to the administrative installation point.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallFiles">
+          <xs:annotation>
+            <xs:documentation>Copies files specified in the File table from the source directory to the destination directory.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="PatchFiles">
+          <xs:annotation>
+            <xs:documentation>Queries the Patch table to determine which patches are to be applied.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallFinalize">
+          <xs:annotation>
+            <xs:documentation>Marks the end of a sequence of actions that change the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="LaunchConditions">
+          <xs:annotation>
+            <xs:documentation>Queries the LaunchCondition table and evaluates each conditional statement recorded there.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ResolveSource" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Determines the location of the source and sets the SourceDir property if the source has not been resolved yet.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="AdvertiseExecuteSequence">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="AdvtExecuteSequence" href="https://docs.microsoft.com/en-us/windows/win32/msi/advtexecutesequence-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="CostInitialize">
+          <xs:annotation>
+            <xs:documentation>Initiates the internal installation costing process.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="CostFinalize">
+          <xs:annotation>
+            <xs:documentation>Ends the internal installation costing process begun by the CostInitialize action.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="Custom" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Use to sequence a custom action. The only custom actions that are allowed in the AdvtExecuteSequence are type 19 (0x013) type 35 (0x023) and type 51 (0x033).</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallValidate">
+          <xs:annotation>
+            <xs:documentation>Verifies that all costed volumes have enough space for the installation.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallInitialize">
+          <xs:annotation>
+            <xs:documentation>Marks the beginning of a sequence of actions that change the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="CreateShortcuts">
+          <xs:annotation>
+            <xs:documentation>Manages the creation of shortcuts.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RegisterClassInfo">
+          <xs:annotation>
+            <xs:documentation>Manages the registration of COM class information with the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RegisterExtensionInfo">
+          <xs:annotation>
+            <xs:documentation>Manages the registration of extension related information with the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RegisterMIMEInfo">
+          <xs:annotation>
+            <xs:documentation>Registers MIME-related registry information with the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RegisterProgIdInfo">
+          <xs:annotation>
+            <xs:documentation>Manages the registration of OLE ProgId information with the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="PublishComponents">
+          <xs:annotation>
+            <xs:documentation>Manages the advertisement of the components from the PublishComponent table.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="PublishFeatures">
+          <xs:annotation>
+            <xs:documentation>Writes each feature's state into the system registry.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="PublishProduct">
+          <xs:annotation>
+            <xs:documentation>Manages the advertisement of the product information with the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="InstallFinalize">
+          <xs:annotation>
+            <xs:documentation>Marks the end of a sequence of actions that change the system.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="MsiPublishAssemblies">
+          <xs:annotation>
+            <xs:documentation>Manages the advertisement of CLR and Win32 assemblies.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Binary">
+    <xs:annotation>
+      <xs:documentation>
+        Binary data used for CustomAction elements and UI controls.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Binary" href="https://learn.microsoft.com/en-us/windows/win32/msi/binary-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema.  Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The Id cannot be longer than 55 characters.  In order to prevent errors in cases where the Id is modularized, it should not be longer than 18 characters.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Path to the binary file.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SuppressModularization" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Use to suppress modularization of this Binary identifier in merge modules.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema.  Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Icon">
+    <xs:annotation>
+      <xs:documentation>
+        Icon used for Shortcut, ProgId, or Class elements (but not UI controls).
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Icon" href="https://learn.microsoft.com/en-us/windows/win32/msi/icon-table" />
+        <xse:howtoRef href="ui_and_localization/configure_arp_appearance.html">How To: Set your installer's icon in Add/Remove Programs</xse:howtoRef>
+        <xse:howtoRef href="files_and_registry/create_start_menu_shortcut.html">How To: Create a shortcut on the Start Menu</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The Id cannot be longer than 55 characters. In order to prevent errors in cases where the Id is modularized, it should not be longer than 18 characters.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Path to the icon file.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="EmbeddedChainer">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiEmbeddedChainer " href="http://msdn.microsoft.com/library/bb736316.aspx" />
+        <xse:seeAlso ref="Binary" />
+        <xse:seeAlso ref="File" />
+        <xse:seeAlso ref="Property" />
+        <xse:seeAlso ref="EmbeddedChainerRef" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Unique identifier for embedded chainer.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="CommandLine" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Value to append to the transaction handle and passed to the chainer executable.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Condition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Value is the condition. It is important to note that each EmbeddedChainer element must have a mutually exclusive condition
+            to ensure that only one embedded chainer will execute at a time. If the conditions are not mutually exclusive the chainer
+            that executes is undeterministic.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="BinarySource" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Reference to the Binary element that contains the chainer executable. Mutually exclusive with
+            the FileSource and PropertySource attributes.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="FileSource" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Reference to the File element that is the chainer executable. Mutually exclusive with
+            the BinarySource and PropertySource attributes.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PropertySource" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Reference to a Property that resolves to the full path to the chainer executable. Mutually exclusive with
+            the BinarySource and FileSource attributes.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="EmbeddedChainerRef">
+    <xs:annotation>
+      <xs:documentation>
+        Reference to an EmbeddedChainer element. This will force the entire referenced Fragment's contents
+        to be included in the installer database.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="EmbeddedChainer" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required" />
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- - - - - - - - - - - UI Definitions - - - - - - - - - - - - - -->
+  <xs:element name="EmbeddedUI">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="MsiEmbeddedUI" href="https://learn.microsoft.com/en-us/windows/win32/msi/msiembeddedui-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="EmbeddedUIResource">
+          <xs:annotation>
+            <xs:documentation>Specifies extra files to be extracted for use by the embedded UI, such as language resources.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Unique identifier for embedded UI. If this attribute is not specified the Name attribute or the file name
+            portion of the SourceFile attribute will be used.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreFatalExit" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_FATALEXIT messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreError" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_ERROR messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreWarning" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_WARNING messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreUser" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_USER messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreInfo" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_INFO messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreFilesInUse" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_FILESINUSE messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreResolveSource" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_RESOLVESOURCE messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreOutOfDiskSpace" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_OUTOFDISKSPACE messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreActionStart" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_ACTIONSTART messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreActionData" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_ACTIONDATA messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreProgress" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_PROGRESS messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreCommonData" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_COMMONDATA messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreInitialize" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_INITIALIZE messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreTerminate" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_TERMINATE messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreShowDialog" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_SHOWDIALOG messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreRMFilesInUse" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_RMFILESINUSE messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreInstallStart" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_INSTALLSTART messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreInstallEnd" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Embedded UI will not recieve any INSTALLLOGMODE_INSTALLEND messages.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="LongFileNameType">
+        <xs:annotation>
+          <xs:documentation>
+            The name for the embedded UI DLL when it is extracted from the MSI package and executed. (Windows Installer
+            does not support the typical short filename and long filename combination for embedded UI files as it
+            does for other kinds of files.) If this attribute is not specified the file name portion of the SourceFile
+            attribute will be used.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceFile" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            Path to the binary file that is the embedded UI. This must be a DLL that exports the following
+            three entry points: InitializeEmbeddedUI, EmbeddedUIHandler and ShutdownEmbeddedUI.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SupportBasicUI" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set yes to allow the Windows Installer to display the embedded UI during basic UI level installation.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="EmbeddedUIResource">
+    <xs:annotation>
+      <xs:documentation>
+        Defines a resource for use by the embedded UI.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="EmbeddedUI" />
+        <xse:msiRef table="MsiEmbeddedUI" href="https://learn.microsoft.com/en-us/windows/win32/msi/msiembeddedui-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier for the embedded UI resource.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Name" type="LongFileNameType" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The name for the resource when it is extracted from the MSI package for use by the embedded UI DLL. (Windows
+            Installer does not support the typical short filename and long filename combination for embedded UI files
+            as it does for other kinds of files.) If this attribute is not specified the Id attribute will be used.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SourceFile" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Path to the binary file that is the embedded UI resource.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Error">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="Error" href="https://learn.microsoft.com/en-us/windows/win32/msi/error-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="Integer">
+        <xs:annotation>
+          <xs:documentation>Number of the error for which a message is being provided. See MSI SDK for error definitions.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Message" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Message to display for the specified error number.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Publish">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="ControlEvent" href="https://learn.microsoft.com/en-us/windows/win32/msi/controlevent-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Condition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Optional condition that determines whether the control event should be published.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Control" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The parent Control for this Publish element, should only be specified when this element is a child of the UI element.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Dialog" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The parent Dialog for this Publish element, should only be specified when this element is a child of the UI element.
+            This attribute will create a reference to the specified Dialog, so an additional DialogRef is not necessary.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Event" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Set this attribute's value to one of the standard control events to trigger that event.
+            Either this attribute or the Property attribute must be set, but not both at the same time.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Order" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute should only need to be set if this element is nested under a UI element in order to
+            control the order in which this publish event will be started.
+            If this element is nested under a Control element, the default value will be one greater than any
+            previous Publish element's order (the first element's default value is 1).
+            If this element is nested under a UI element, the default value is always 1 (it does not get a
+            default value based on any previous Publish elements).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Property" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Set this attribute's value to a property name to set that property.
+            Either this attribute or the Event attribute must be set, but not both at the same time.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            If the Property attribute is specified, set the value of this attribute to the new value for the property.
+            To set a property to null, do not set this attribute (the ControlEvent Argument column will be set to '{}').
+            Otherwise, this attribute's value should be the argument for the event specified in the Event attribute.
+            If the event doesn't take an attribute, a common value to use is "0".
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Subscribe">
+    <xs:annotation>
+      <xs:documentation>
+        Sets attributes for events in the EventMapping table
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="EventMapping" href="https://learn.microsoft.com/en-us/windows/win32/msi/eventmapping-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Event" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>must be one of the standard control events'</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Attribute" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>if not present can only handle enable, disable, hide, unhide events</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Text">
+    <xs:annotation>
+      <xs:documentation>
+        An alternative to using the Text attribute on the Control element.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="SourceFile" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Instructs the text to be imported from a file instead of the element value during the binding process.
+            Cannot be specified with the Value attribute.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The value of the control's text. Cannot be specified with the SourceFile attribute.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Control">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="Control" href="https://docs.microsoft.com/en-us/windows/win32/msi/control-table" />
+        <xse:msiRef table="ComboBox" href="https://docs.microsoft.com/en-us/windows/win32/msi/combobox-table" />
+        <xse:msiRef table="Dialog" href="https://docs.microsoft.com/en-us/windows/win32/msi/dialog-table" />
+        <xse:msiRef table="ListBox" href="https://docs.microsoft.com/en-us/windows/win32/msi/listbox-table" />
+        <xse:msiRef table="ListView" href="https://docs.microsoft.com/en-us/windows/win32/msi/listview-table" />
+        <xse:msiRef table="RadioButton" href="https://docs.microsoft.com/en-us/windows/win32/msi/radiobutton-table" />
+      </xs:appinfo>
+      <xs:documentation>Contains the controls that appear on each dialog.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="Text" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Alternative to Text attribute.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ComboBox" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>ComboBox table with ListItem children</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ListBox" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>ListBox table with ListItem children</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="ListView" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>ListView table with ListItem children</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="RadioButtonGroup" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>RadioButton table with RadioButton children</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="Property" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Property table entry for the Property table column associated with this control</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="Binary" minOccurs="0">
+          <xs:annotation>
+            <xs:documentation>Icon referenced in icon column of row</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Child elements affecting operation of this control</xs:documentation>
+          </xs:annotation>
+          <xs:element ref="Publish" />
+          <xs:element ref="Subscribe" />
+          <xs:any namespace="##other" processContents="lax">
+            <xs:annotation>
+              <xs:documentation>
+                Extensibility point in the WiX XML Schema. Schema extensions can register additional
+                elements at this point in the schema.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:any>
+        </xs:choice>
+      </xs:sequence>
+      <xs:attribute name="Id" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Combined with the Dialog Id to make up the primary key of the Control table.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Type" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The type of the control. Could be one of the following: Billboard, Bitmap, CheckBox, ComboBox, DirectoryCombo, DirectoryList, Edit, GroupBox, Hyperlink, Icon, Line, ListBox, ListView, MaskedEdit, PathEdit, ProgressBar, PushButton, RadioButtonGroup, ScrollableText, SelectionTree, Text, VolumeCostList, VolumeSelectCombo</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="X" use="required" type="LocalizableInteger">
+        <xs:annotation>
+          <xs:documentation>Horizontal coordinate of the upper-left corner of the rectangular boundary of the control. This must be a non-negative number.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Y" use="required" type="LocalizableInteger">
+        <xs:annotation>
+          <xs:documentation>Vertical coordinate of the upper-left corner of the rectangular boundary of the control. This must be a non-negative number.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Width" use="required" type="LocalizableInteger">
+        <xs:annotation>
+          <xs:documentation>Width of the rectangular boundary of the control. This must be a non-negative number.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Height" use="required" type="LocalizableInteger">
+        <xs:annotation>
+          <xs:documentation>Height of the rectangular boundary of the control. This must be a non-negative number.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Property" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The name of a defined property to be linked to this control. This column is required for active controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Text" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>A localizable string used to set the initial text contained in a control. This attribute can contain a formatted string that is processed at install time to insert the values of properties using [PropertyName] syntax. Also supported are environment variables, file installation paths, and component installation directories; see <html:a href="https://learn.microsoft.com/en-us/windows/win32/msi/formatted">Formatted</html:a> for details.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Help" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>This attribute is reserved for future use. There is no need to use this until Windows Installer uses it for something.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ToolTip" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The string used for the Tooltip.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="CheckBoxValue" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for CheckBox Controls. When set, the linked Property will be set to this value when the check box is checked.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="CheckBoxPropertyRef" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for CheckBox controls. The value is the name of a Property that was already used as the Property for another CheckBox control. The Property attribute cannot be specified. The attribute exists to support multiple checkboxes on different dialogs being tied to the same property.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+
+      <xs:attribute name="TabSkip" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set this attribute to "yes" to cause this Control to be skipped in the tab sequence.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Default" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set this attribute to "yes" to cause this Control to be invoked by the return key.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Cancel" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set this attribute to "yes" to cause this Control to be invoked by the escape key.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+
+      <xs:attribute name="DefaultCondition">
+        <xs:annotation>
+          <xs:documentation>
+            When the condition expression evaluates to true, set the Control as the default.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="EnableCondition">
+        <xs:annotation>
+          <xs:documentation>
+            When the condition expression evaluates to true, enable the Control.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DisableCondition">
+        <xs:annotation>
+          <xs:documentation>
+            When the condition expression evaluates to true, disable the Control.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="HideCondition">
+        <xs:annotation>
+          <xs:documentation>
+            When the condition expression evaluates to true, hide the Control.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ShowCondition">
+        <xs:annotation>
+          <xs:documentation>
+            When the condition expression evaluates to true, show the Control.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Hidden" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set this attribute to "yes" to cause the Control to be hidden.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Disabled" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set this attribute to "yes" to cause the Control to be disabled.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Sunken" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set this attribute to "yes" to cause the Control to be sunken.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Indirect" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Specifies whether the value displayed or changed by this control is referenced indirectly. If this bit is set, the control displays or changes the value of the property that has the identifier listed in the Property column of the Control table.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Integer" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set this attribute to "yes" to cause the linked Property value for the Control to be treated as an integer. Otherwise, the Property will be treated as a string.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RightToLeft" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set this attribute to "yes" to cause the Control to display from right to left.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RightAligned" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set this attribute to "yes" to cause the Control to be right aligned.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="LeftScroll" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set this attribute to "yes" to cause the scroll bar to display on the left side of the Control.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+
+      <xs:attribute name="Transparent" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for Text Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="NoPrefix" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for Text Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="NoWrap" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for Text Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="FormatSize" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for Text Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UserLanguage" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for Text Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Multiline" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for Edit Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Password" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for Edit Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProgressBlocks" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for ProgressBar Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Removable" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for Volume and Directory Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Fixed" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for Volume and Directory Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Remote" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for Volume and Directory Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="CDROM" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for Volume and Directory Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RAMDisk" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for Volume and Directory Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Floppy" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for Volume and Directory Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ShowRollbackCost" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for VolumeCostList Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Sorted" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute is only valid for ListBox, ListView, and ComboBox Controls. Set
+            the value of this attribute to "yes" to have entries appear in the order specified under the Control.
+            If the attribute value is "no" or absent the entries in the control will appear in alphabetical order.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ComboList" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for ComboBox Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Image" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for RadioButton, PushButton, and Icon Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IconSize">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for RadioButton, PushButton, and Icon Controls.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="16" />
+            <xs:enumeration value="32" />
+            <xs:enumeration value="48" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="FixedSize" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for RadioButton, PushButton, and Icon Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Icon" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for RadioButton and PushButton Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Bitmap" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for RadioButton and PushButton Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PushLike" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for RadioButton and Checkbox Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="HasBorder" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>This attribute is only valid for RadioButton Controls.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ElevationShield" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute is only valid for PushButton controls.
+            Set this attribute to "yes" to add the User Account Control (UAC) elevation icon (shield icon) to the PushButton control.
+            If this attribute's value is "yes" and the installation is not yet running with elevated privileges,
+            the pushbutton control is created using the User Account Control (UAC) elevation icon (shield icon).
+            If this attribute's value is "yes" and the installation is already running with elevated privileges,
+            the pushbutton control is created using the other icon attributes.
+            Otherwise, the pushbutton control is created using the other icon attributes.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Billboard">
+    <xs:annotation>
+      <xs:documentation>
+        Billboard to display during install of a Feature
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Billboard" href="https://learn.microsoft.com/en-us/windows/win32/msi/billboard-table" />
+        <xse:msiRef table="BBControl" href="https://learn.microsoft.com/en-us/windows/win32/msi/bbcontrol-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="Control" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Only controls of static type such as: Text, Bitmap, Icon, or custom control can be placed on a billboard.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Unique identifier for the Billboard.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Feature" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Feature whose state determines if the Billboard is shown.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="BillboardAction">
+    <xs:annotation>
+      <xs:documentation>
+        Billboard action during which child Billboards are displayed
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Billboard" href="https://learn.microsoft.com/en-us/windows/win32/msi/billboard-table" />
+        <xse:msiRef table="BBControl" href="https://learn.microsoft.com/en-us/windows/win32/msi/bbcontrol-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="Billboard" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Order of Billboard elements determines order of display</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Action name that determines when the Billboard should be shown.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Dialog">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="Control" href="https://docs.microsoft.com/en-us/windows/win32/msi/control-table" />
+        <xse:msiRef table="ComboBox" href="https://docs.microsoft.com/en-us/windows/win32/msi/combobox-table" />
+        <xse:msiRef table="Dialog" href="https://docs.microsoft.com/en-us/windows/win32/msi/dialog-table" />
+        <xse:msiRef table="ListBox" href="https://docs.microsoft.com/en-us/windows/win32/msi/listbox-table" />
+        <xse:msiRef table="ListView" href="https://docs.microsoft.com/en-us/windows/win32/msi/listview-table" />
+        <xse:msiRef table="RadioButton" href="https://docs.microsoft.com/en-us/windows/win32/msi/radiobutton-table" />
+      </xs:appinfo>
+      <xs:documentation>
+        Defines a dialog box in the Dialog Table.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Control">
+          <xs:annotation>
+            <xs:documentation>Control elements belonging to this dialog.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Unique identifier for the dialog.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="X" type="Integer">
+        <xs:annotation>
+          <xs:documentation>Horizontal placement of the dialog box as a percentage of screen width. The default value is 50.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Y" type="Integer">
+        <xs:annotation>
+          <xs:documentation>Vertical placement of the dialog box as a percentage of screen height. The default value is 50.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Width" use="required" type="Integer">
+        <xs:annotation>
+          <xs:documentation>The width of the dialog box in dialog units.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Height" use="required" type="Integer">
+        <xs:annotation>
+          <xs:documentation>The height of the dialog box in dialog units.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Title" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The title of the dialog box.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+
+      <xs:attribute name="Hidden" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Used to hide the dialog.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Modeless" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Used to set the dialog as modeless.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="NoMinimize" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Used to specify if the dialog can be minimized.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="SystemModal" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Used to set the dialog as system modal.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="KeepModeless" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Keep modeless dialogs alive when this dialog is created through DoAction.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="TrackDiskSpace" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Have the dialog periodically call the installer to check if available disk space has changed.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="CustomPalette" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Used to specify if pictures in the dialog box are rendered with a custom palette.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RightToLeft" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Used to specify if the text in the dialog should be displayed in right to left reading order.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RightAligned" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Align text on the right.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="LeftScroll" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Used to align the scroll bar on the left.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ErrorDialog" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Specifies this dialog as an error dialog.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="DialogRef">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="Dialog" />
+      </xs:appinfo>
+      <xs:documentation>
+        Reference to a Dialog. This will cause the entire referenced section's contents
+        to be included in the installer database.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the Dialog to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ProgressText">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="ActionText" href="https://learn.microsoft.com/en-us/windows/win32/msi/actiontext-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Action" type="xs:string" use="required" />
+      <xs:attribute name="Message" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Element value is progress message text for action.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Template" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Used to format ActionData messages from action processing</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="TextStyle">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="TextStyle" href="https://docs.microsoft.com/en-us/windows/win32/msi/textstyle-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            An optional identifier for the text style in the database. If one is not specified,
+            one will be generated.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="FaceName" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The face name of the font.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Size" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The font's size.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Red" type="Integer">
+        <xs:annotation>
+          <xs:documentation>A value from 0 to 255 to indicate the amount of red in the font.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Green" type="Integer">
+        <xs:annotation>
+          <xs:documentation>A value from 0 to 255 to indicate the amount of green in the font.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Blue" type="Integer">
+        <xs:annotation>
+          <xs:documentation>A value from 0 to 255 to indicate the amount of blue in the font.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Bold" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Indicates whether the font should be bold. Default is 'false'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Italic" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Indicates whether the font should be italic. Default is 'false'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Underline" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Indicates whether the font should be underline. Default is 'false'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Strike" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Indicates whether the font should be strikethrough. Default is 'false'.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ListItem">
+    <xs:annotation>
+      <xs:documentation>
+        The value (and optional text) associated with an item in a ComboBox, ListBox, or ListView.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="ComboBox" href="https://docs.microsoft.com/en-us/windows/win32/msi/combobox-table" />
+        <xse:msiRef table="ListBox" href="https://docs.microsoft.com/en-us/windows/win32/msi/listbox-table" />
+        <xse:msiRef table="ListView" href="https://docs.microsoft.com/en-us/windows/win32/msi/listview-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Value" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The value assigned to the associated ComboBox, ListBox, or ListView property if this item is selected.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Text" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The localizable, visible text to be assigned to the item.
+            If not specified, this will default to the value of the Value attribute.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Icon" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The identifier of the Binary (not Icon) element containing the icon to associate with this item.
+            This value is only valid when nested under a ListView element.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ListBox">
+    <xs:annotation>
+      <xs:documentation>
+        Set of items for a particular ListBox control tied to an install Property
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="Control" href="https://docs.microsoft.com/en-us/windows/win32/msi/control-table" />
+        <xse:msiRef table="Dialog" href="https://docs.microsoft.com/en-us/windows/win32/msi/dialog-table" />
+        <xse:msiRef table="ListView" href="https://docs.microsoft.com/en-us/windows/win32/msi/listview-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="ListItem">
+          <xs:annotation>
+            <xs:documentation>entry for ListBox table</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="Property" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Property tied to this group</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ComboBox">
+    <xs:annotation>
+      <xs:documentation>
+        Set of items for a particular ComboBox control tied to an install Property
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="ComboBox" href="https://docs.microsoft.com/en-us/windows/win32/msi/combobox-table" />
+        <xse:msiRef table="Control" href="https://docs.microsoft.com/en-us/windows/win32/msi/control-table" />
+        <xse:msiRef table="Dialog" href="https://docs.microsoft.com/en-us/windows/win32/msi/dialog-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="ListItem">
+          <xs:annotation>
+            <xs:documentation>entry for ComboBox table</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="Property" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Property tied to this group</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ListView">
+    <xs:annotation>
+      <xs:documentation>
+        Set of items for a particular ListView control tied to an install Property
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="ListView" href="https://docs.microsoft.com/en-us/windows/win32/msi/listview-table" />
+        <xse:msiRef table="Control" href="https://docs.microsoft.com/en-us/windows/win32/msi/control-table" />
+        <xse:msiRef table="Dialog" href="https://docs.microsoft.com/en-us/windows/win32/msi/dialog-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="ListItem">
+          <xs:annotation>
+            <xs:documentation>entry for ListView table</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="Property" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Property tied to this group</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RadioButton">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:seeAlso ref="RadioButtonGroup" />
+        <xse:msiRef table="RadioButton" href="https://docs.microsoft.com/en-us/windows/win32/msi/radiobutton-table" />
+        <xse:msiRef table="Control" href="https://docs.microsoft.com/en-us/windows/win32/msi/control-table" />
+        <xse:msiRef table="Dialog" href="https://docs.microsoft.com/en-us/windows/win32/msi/dialog-table" />
+      </xs:appinfo>
+      <xs:documentation>Text or Icon plus Value that is assigned to the Property of the parent Control (RadioButtonGroup).</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Bitmap" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute defines the bitmap displayed with the radio button. The value of the attribute creates a reference
+            to a Binary element that represents the bitmap. This attribute is mutually exclusive with the Icon and Text
+            attributes.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Height" use="required" type="LocalizableInteger" />
+      <xs:attribute name="Help" type="xs:string" />
+      <xs:attribute name="Icon" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            This attribute defines the icon displayed with the radio button. The value of the attribute creates a reference
+            to a Binary element that represents the icon. This attribute is mutually exclusive with the Bitmap and Text
+            attributes.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Text" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Text displayed with the radio button. This attribute is mutually exclusive with the Bitmap and Icon attributes.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ToolTip" type="xs:string" />
+      <xs:attribute name="Value" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Value assigned to the associated control Property when this radio button is selected.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Width" use="required" type="LocalizableInteger" />
+      <xs:attribute name="X" use="required" type="LocalizableInteger" />
+      <xs:attribute name="Y" use="required" type="LocalizableInteger" />
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RadioButtonGroup">
+    <xs:annotation>
+      <xs:documentation>
+        Set of radio buttons tied to the specified Property
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="RadioButton" href="https://docs.microsoft.com/en-us/windows/win32/msi/radiobutton-table" />
+        <xse:msiRef table="Control" href="https://docs.microsoft.com/en-us/windows/win32/msi/control-table" />
+        <xse:msiRef table="Dialog" href="https://docs.microsoft.com/en-us/windows/win32/msi/dialog-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="RadioButton" maxOccurs="unbounded" />
+      </xs:sequence>
+      <xs:attribute name="Property" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Property tied to this group.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="UIText">
+    <xs:annotation>
+      <xs:documentation>
+        Text associated with certain controls.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:msiRef table="UIText" href="https://docs.microsoft.com/en-us/windows/win32/msi/uitext-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            An optional identifier for the text style in the database. If one is not specified,
+            one will be generated.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The UI text.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="UIRef">
+    <xs:annotation>
+      <xs:documentation>
+        Reference to a UI element. This will force the entire referenced Fragment's contents
+        to be included in the installer database.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="UI" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required" />
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="UI">
+    <xs:annotation>
+      <xs:documentation>
+        Enclosing element to compartmentalize UI specifications.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:seeAlso ref="UIRef" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="BillboardAction" />
+        <xs:element ref="ComboBox" />
+        <xs:element ref="Dialog" />
+        <xs:element ref="DialogRef" />
+        <xs:element ref="EmbeddedUI" />
+        <xs:element ref="Error" />
+        <xs:element ref="ListBox" />
+        <xs:element ref="ListView"/>
+        <xs:element ref="ProgressText"/>
+        <xs:element ref="Publish" />
+        <xs:element ref="RadioButtonGroup"/>
+        <xs:element ref="TextStyle" />
+        <xs:element ref="UIText"/>
+        <!--
+          Elements with identical behavior as under Package/Fragment element, solely to allow grouping with other UI elements
+        -->
+        <xs:element ref="AdminUISequence" />
+        <xs:element ref="InstallUISequence" />
+        <xs:element ref="Binary" />
+        <xs:element ref="Property" />
+        <xs:element ref="PropertyRef" />
+        <xs:element ref="UIRef" />
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" />
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="CustomTable">
+    <xs:annotation>
+      <xs:documentation>Defines a custom table for use from a custom action.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="Column">
+          <xs:annotation>
+            <xs:documentation>Column definition for the custom table.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element ref="Row">
+          <xs:annotation>
+            <xs:documentation>Row definition for the custom table.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier for the custom table. The id must be less than 31 characters.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Unreal" type="YesNoType">
+        <xs:annotation>
+          <xs:documentation>Indicates the table is not supposed to be included in the final output.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Column">
+    <xs:annotation>
+      <xs:documentation>Column definition for a Custom Table</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Identifier for the column.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="PrimaryKey" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Whether this column is a primary key.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Type" use="required">
+        <xs:annotation>
+          <xs:documentation>The type of this column.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="binary">
+              <xs:annotation>
+                <xs:documentation>
+                  Column contains a path to a file that will be inserted into the column as a binary object.
+                  If this value is set, the Category attribute must also be set with a value of 'Binary' to pass ICE validation.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="int">
+              <xs:annotation>
+                <xs:documentation>
+                  Column contains an integer or datetime value (the MinValue and MaxValue attributes should also be set).
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="string">
+              <xs:annotation>
+                <xs:documentation>
+                  Column contains a non-localizable string value.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Width" type="Integer">
+        <xs:annotation>
+          <xs:documentation>Width of this column.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Nullable" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Whether this column can be left null.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Localizable" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Whether this column can be localized.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MinValue" type="xs:long">
+        <xs:annotation>
+          <xs:documentation>Minimum value for a numeric value, date or version in this column.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MaxValue" type="xs:long">
+        <xs:annotation>
+          <xs:documentation>Maximum value for a numeric value, date or version in this column.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="KeyTable" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Table in which this column is an external key. Can be semicolon delimited.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="KeyColumn" type="Integer">
+        <xs:annotation>
+          <xs:documentation>Column in the table in KeyTable attribute.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Category">
+        <xs:annotation>
+          <xs:documentation>
+            Category of this column.
+            This attribute must be specified with a value of 'Binary' if the Type attribute's value is 'binary'.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="text" />
+            <xs:enumeration value="upperCase" />
+            <xs:enumeration value="lowerCase" />
+            <xs:enumeration value="integer" />
+            <xs:enumeration value="doubleInteger" />
+            <xs:enumeration value="timeDate" />
+            <xs:enumeration value="identifier" />
+            <xs:enumeration value="property" />
+            <xs:enumeration value="filename" />
+            <xs:enumeration value="wildCardFilename" />
+            <xs:enumeration value="path" />
+            <xs:enumeration value="paths" />
+            <xs:enumeration value="anyPath" />
+            <xs:enumeration value="defaultDir" />
+            <xs:enumeration value="regPath" />
+            <xs:enumeration value="formatted" />
+            <xs:enumeration value="formattedSddl" />
+            <xs:enumeration value="template" />
+            <xs:enumeration value="condition" />
+            <xs:enumeration value="guid" />
+            <xs:enumeration value="version" />
+            <xs:enumeration value="language" />
+            <xs:enumeration value="binary" />
+            <xs:enumeration value="customSource" />
+            <xs:enumeration value="cabinet" />
+            <xs:enumeration value="shortcut" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="Set" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Semicolon delimited list of permissible values.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Description" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Description of this column.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Modularize">
+        <xs:annotation>
+          <xs:documentation>How this column should be modularized, if at all.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="none">
+              <xs:annotation>
+                <xs:documentation>
+                  Column should not be modularized. This is the default value.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="column">
+              <xs:annotation>
+                <xs:documentation>
+                  Column should be modularized.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="condition">
+              <xs:annotation>
+                <xs:documentation>
+                  Column is a condition and should be modularized.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="icon">
+              <xs:annotation>
+                <xs:documentation>
+                  When the column is an primary or foreign key to the Icon table it should be modularized special.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="property">
+              <xs:annotation>
+                <xs:documentation>
+                  Any Properties in the column should be modularized.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="semicolonDelimited">
+              <xs:annotation>
+                <xs:documentation>
+                  Semi-colon list of keys, all of which need to be modularized.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Row">
+    <xs:annotation>
+      <xs:documentation>Row data for a Custom Table</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element ref="Data"/>
+        <xs:any namespace="##other" processContents="lax">
+          <xs:annotation>
+            <xs:documentation>
+              Extensibility point in the WiX XML Schema. Schema extensions can register additional
+              elements at this point in the schema.
+            </xs:documentation>
+          </xs:annotation>
+        </xs:any>
+      </xs:choice>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Data">
+    <xs:annotation>
+      <xs:documentation>Used for a Custom Table. Specifies the data for the parent Row and specified Column.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Column" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>Specifies in which column to insert this data.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Specifies the optional data for this column.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CustomTableRef">
+    <xs:annotation>
+      <xs:documentation>Used to reference a CustomTable element and optionally add more data.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="Row" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>Row definition for the custom table.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The identifier of the CustomTable element to reference.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="EnsureTable">
+    <xs:annotation>
+      <xs:documentation>
+        Use this element to ensure that a table appears in the installer database, even if its empty.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:remarks>
+          This element is particularly useful for two problems that may occur while merging merge modules:
+
+          * The first likely problem is that in order to properly merge you need to have certain
+            tables present prior to merging. Using this element is one way to ensure those tables
+            are present prior to the merging.
+
+          * The other common problem is that a merge module has incorrect validation information
+            about some tables. By ensuring these tables prior to merging, you can avoid this
+            problem because the correct validation information will go into the installer database
+            before the merge module has a chance to set it incorrectly.
+        </xse:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" use="required" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The name of the table.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="WixVariable">
+    <xs:annotation>
+      <xs:documentation>
+        This element exposes advanced WiX functionality. Use this element to declare WiX variables
+        from directly within your authoring. WiX variables are not resolved until the final msi/msm/pcp
+        file is actually generated. WiX variables do not persist into the msi/msm/pcp file, so they cannot
+        be used when an MSI file is being installed; it's a WiX-only concept.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The name of the variable.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Overridable" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            Set this value to 'yes' in order to make the variable's value overridable either by
+            another WixVariable entry or via the command-line option -d_name_=_value_;
+            for light.exe. If the same variable is declared overridable in multiple places it
+            will cause an error (since WiX won't know which value is correct). The default value
+            is 'no'.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Value" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The value of the variable. The value cannot be an empty string because that would
+            make it possible to accidentally set a column to null.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="InstanceTransforms">
+    <xs:annotation>
+      <xs:documentation>
+        Use this element to contain definitions for instance transforms.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Instance" />
+      </xs:choice>
+      <xs:attribute name="Property" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>The Id of the Property who's value should change for each instance.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Instance">
+    <xs:annotation>
+      <xs:documentation>
+        Defines an instance transform for your product.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The identity of the instance transform. This value will define the name by which the instance
+            should be referred to on the command line. In addition, the value of the this attribute will
+            determine what the value of the property specified in Property attribute on InstanceTransforms
+            will change to for each instance.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProductCode" type="AutogenGuid" use="required">
+        <xs:annotation>
+          <xs:documentation>The ProductCode for this instance.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProductName" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The ProductName for this instance.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UpgradeCode" type="Guid">
+        <xs:annotation>
+          <xs:documentation>The UpgradeCode for this instance.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="MajorUpgrade">
+    <xs:annotation>
+      <xs:documentation>
+        Simplifies authoring for major upgrades, including support for preventing downgrades.
+
+        The parent Package element must have valid UpgradeCode and Version attributes.
+
+        When the FindRelatedProducts action detects a related product installed on the system,
+        it appends the product code to the property named WIX_UPGRADE_DETECTED. After the
+        FindRelatedProducts action is run, the value of the WIX_UPGRADE_DETECTED property is a
+        list of product codes, separated by semicolons (;), detected on the system.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:parent namespace="http://wixtoolset.org/schemas/v4/wxs" ref="Package" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="AllowDowngrades" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            When set to no (the default), products with lower version numbers are blocked from
+            installing when a product with a higher version is installed; the DowngradeErrorMessage
+            attribute must also be specified.
+
+            When set to yes, any version can be installed over any other version.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="AllowSameVersionUpgrades" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            When set to no (the default), installing a product with the same version and upgrade code
+            (but different product code) is allowed and treated by MSI as two products. When set to yes,
+            WiX sets the msidbUpgradeAttributesVersionMaxInclusive attribute, which tells MSI to treat
+            a product with the same version as a major upgrade.
+
+            This is useful when two product versions differ only in the fourth version field. MSI
+            specifically ignores that field when comparing product versions, so two products that
+            differ only in the fourth version field are the same product and need this attribute set to
+            yes to be detected.
+
+            Note that because MSI ignores the fourth product version field, setting this attribute to
+            yes also allows downgrades when the first three product version fields are identical.
+            For example, product version 1.0.0.1 will "upgrade" 1.0.0.2998 because they're seen as the
+            same version (1.0.0). That could reintroduce serious bugs so the safest choice is to change
+            the first three version fields and omit this attribute to get the default of no.
+
+            This attribute cannot be "yes" when AllowDowngrades is also "yes" -- AllowDowngrades
+            already allows two products with the same version number to upgrade each other.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Disallow" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            When set to yes, products with higer version numbers are blocked from
+            installing when a product with a lower version is installed; the UpgradeErrorMessage
+            attribute must also be specified.
+
+            When set to no (the default), any version can be installed over any lower version.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DowngradeErrorMessage" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The message displayed if users try to install a product with a lower version number
+            when a product with a higher version is installed. Used only when AllowDowngrades
+            is no (the default).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DisallowUpgradeErrorMessage" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            The message displayed if users try to install a product with a higer version number
+            when a product with a lower version is installed. Used only when Disallow
+            is yes.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="MigrateFeatures" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            When set to yes (the default), the MigrateFeatureStates standard action will set the
+            feature states of the upgrade product to those of the installed product.
+
+            When set to no, the installed features have no effect on the upgrade installation.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreLanguage" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            When set to yes, the Upgrade table rows will match any product with the same UpgradeCode.
+
+            When set to no (the default), the Upgrade table rows will match only products with the
+            same UpgradeCode and ProductLanguage.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IgnoreRemoveFailure" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>
+            When set to yes, failures removing the installed product during the upgrade will be
+            ignored.
+
+            When set to no (the default), failures removing the installed product during the upgrade
+            will be considered a failure and, depending on the scheduling, roll back the upgrade.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RemoveFeatures" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            A formatted string that contains the list of features to remove from the installed
+            product. The default is to remove all features. Note that if you use formatted property
+            values that evaluate to an empty string, no features will be removed; only omitting
+            this attribute defaults to removing all features.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Schedule" default="afterInstallValidate">
+        <xs:annotation>
+          <xs:documentation>
+            Determines the scheduling of the RemoveExistingProducts standard action, which is when
+            the installed product is removed. The default is "afterInstallValidate" which removes
+            the installed product entirely before installing the upgrade product. It's slowest but
+            gives the most flexibility in changing components and features in the upgrade product.
+
+            For more information, see <html:a href="https://learn.microsoft.com/en-us/windows/win32/msi/removeexistingproducts-action">RemoveExistingProducts</html:a>.
+          </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:NMTOKEN">
+            <xs:enumeration value="afterInstallValidate">
+              <xs:annotation>
+                <xs:documentation>
+                  (Default) Schedules RemoveExistingProducts after the InstallValidate standard
+                  action. This scheduling removes the installed product entirely before installing
+                  the upgrade product. It's slowest but gives the most flexibility in changing
+                  components and features in the upgrade product. Note that if the installation
+                  of the upgrade product fails, the machine will have neither version installed.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="afterInstallInitialize">
+              <xs:annotation>
+                <xs:documentation>
+                  Schedules RemoveExistingProducts after the InstallInitialize standard action.
+                  This is similar to the afterInstallValidate scheduling, but if the installation
+                  of the upgrade product fails, Windows Installer also rolls back the removal of
+                  the installed product -- in other words, reinstalls it.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="afterInstallExecute">
+              <xs:annotation>
+                <xs:documentation>
+                  Schedules RemoveExistingProducts between the InstallExecute and InstallFinalize standard actions.
+                  This scheduling installs the upgrade product "on top of" the installed product then lets
+                  RemoveExistingProducts uninstall any components that don't also exist in the upgrade product.
+                  Note that this scheduling requires strict adherence to the component rules because it relies
+                  on component reference counts to be accurate during installation of the upgrade product and
+                  removal of the installed product. For more information, see
+                  <html:a href="http://www.joyofsetup.com/2008/12/30/paying-for-upgrades/">Bob Arnson's blog post "Paying for Upgrades"</html:a> for details. If installation of the upgrade product fails, Windows Installer
+                  also rolls back the removal of the installed product -- in other words, reinstalls it.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="afterInstallExecuteAgain">
+              <xs:annotation>
+                <xs:documentation>
+                  Schedules RemoveExistingProducts between the InstallExecuteAgain and InstallFinalize standard actions.
+                  This is identical to the afterInstallExecute scheduling but after the InstallExecuteAgain standard
+                  action instead of InstallExecute.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="afterInstallFinalize">
+              <xs:annotation>
+                <xs:documentation>
+                  Schedules RemoveExistingProducts after the InstallFinalize standard action. This is similar to the
+                  afterInstallExecute and afterInstallExecuteAgain schedulings but takes place outside the
+                  installation transaction so if installation of the upgrade product fails, Windows Installer does
+                  not roll back the removal of the installed product, so the machine will have both versions
+                  installed.
+                </xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="ProductSearch">
+    <xs:annotation>
+      <xs:appinfo>
+        <xse:msiRef table="Upgrade" href="https://learn.microsoft.com/en-us/windows/win32/msi/upgrade-table" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Minimum" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Specifies the lower bound on the range of product versions to be detected by FindRelatedProducts.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Maximum" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Specifies the upper boundary of the range of product versions detected by FindRelatedProducts.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Language" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Specifies the set of languages detected by FindRelatedProducts. Enter a list of numeric language identifiers (LANGID) separated by commas (,). Leave this value null to specify all languages. Set ExcludeLanguages to "yes" in order detect all languages, excluding the languages listed in this value.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IncludeMinimum" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set to "no" to make the range of versions detected exclude the value specified in Minimum. This attribute is "yes" by default.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IncludeMaximum" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set to "yes" to make the range of versions detected include the value specified in Maximum.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ExcludeLanguages" type="YesNoTypeUnion">
+        <xs:annotation>
+          <xs:documentation>Set to "yes" to detect all languages, excluding the languages listed in the Language attribute.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UpgradeCode" type="Guid" use="required">
+        <xs:annotation>
+          <xs:documentation>This value specifies the upgrade code for the products that are to be detected by the FindRelatedProducts action.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional
+            attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <!-- - - - - - - - - - - Complex Type Definitions  - - - - - - - - - - - -->
+  <xs:complexType name="ActionModuleSequenceType">
+    <xs:attribute name="After" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>The name of an action that this action should come after.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Before" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>The name of an action that this action should come before.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Condition" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>The condition of the action.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Overridable" type="YesNoTypeUnion">
+      <xs:annotation>
+        <xs:documentation>
+          If "yes", the sequencing of this action may be overridden by sequencing elsewhere.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Sequence" type="Integer">
+      <xs:annotation>
+        <xs:documentation>A value used to indicate the position of this action in a sequence.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Suppress" type="YesNoTypeUnion">
+      <xs:annotation>
+        <xs:documentation>If yes, this action will not occur.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="ActionSequenceType">
+    <xs:attribute name="Condition" type="xs:string">
+      <xs:annotation>
+        <xs:documentation>The condition of the action.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Sequence" type="Integer">
+      <xs:annotation>
+        <xs:documentation>A value used to indicate the position of this action in a sequence.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="Suppress" type="YesNoTypeUnion">
+      <xs:annotation>
+        <xs:documentation>If yes, this action will not occur.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <!-- - - - - - - - - - - Simple Type Definitions - - - - - - - - - - - - -->
+  <xs:simpleType name="Guid">
+    <xs:annotation>
+      <xs:documentation>Values of this type will look like: "01234567-89AB-CDEF-0123-456789ABCDEF" or "{01234567-89AB-CDEF-0123-456789ABCDEF}". Also allows "PUT-GUID-HERE" for use in examples.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[{(]?[0-9A-Fa-f]{8}\-?[0-9A-Fa-f]{4}\-?[0-9A-Fa-f]{4}\-?[0-9A-Fa-f]{4}\-?[0-9A-Fa-f]{12}[})]?|PUT\-GUID\-(\d+\-)?HERE|([!$])(\(var|\(loc|\(wix)\.[_A-Za-z][0-9A-Za-z_.]*\)" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AutogenGuid">
+    <xs:annotation>
+      <xs:documentation>Values of this type will look like: "01234567-89AB-CDEF-0123-456789ABCDEF" or "{01234567-89AB-CDEF-0123-456789ABCDEF}". A GUID can be auto-generated by setting the value to "*". Also allows "PUT-GUID-HERE" for use in examples.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[{(]?[0-9A-Fa-f]{8}\-?[0-9A-Fa-f]{4}\-?[0-9A-Fa-f]{4}\-?[0-9A-Fa-f]{4}\-?[0-9A-Fa-f]{12}[})]?|[{(]?\?{8}\-\?{4}\-\?{4}\-\?{4}\-\?{12}[})]?|PUT\-GUID\-(\d+\-)?HERE|([!$])(\(var|\(loc|\(wix)\.[_A-Za-z][0-9A-Za-z_.]*\)|\*" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="BitnessTypeUnion">
+    <xs:annotation>
+      <xs:documentation>Values of this type will be "default", "always32" or "always64".</xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="BitnessType PreprocessorVariables"/>
+  </xs:simpleType>
+  <xs:simpleType name="BitnessType">
+    <xs:annotation>
+      <xs:documentation>Values of this type will be "default", "always32" or "always64".</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="default" />
+      <xs:enumeration value="always32" />
+      <xs:enumeration value="always64" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="BurnContainerType">
+    <xs:annotation>
+      <xs:documentation>Values of this type will either be "attached" or "detached".</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="attached" />
+      <xs:enumeration value="detached" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="BurnExeProtocolType">
+    <xs:annotation>
+      <xs:documentation>The list of communcation protocols with executable packages Burn supports.
+          </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="none">
+        <xs:annotation>
+          <xs:documentation>
+                The executable package does not support a communication protocol.
+              </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="burn">
+        <xs:annotation>
+          <xs:documentation>
+                The executable package implements the Burn communication protocol.
+              </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="netfx4">
+        <xs:annotation>
+          <xs:documentation>
+                The executable package implements the .NET Framework v4.0 communication protocol.
+              </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ComponentGuid">
+    <xs:annotation>
+      <xs:documentation>Values of this type must be a GUID, with or without braces: `01234567-89AB-CDEF-0123-456789ABCDEF` or `{01234567-89AB-CDEF-0123-456789ABCDEF}`. `PUT-GUID-HERE` can be used for sample code. Empty values are also supported.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[{(]?[0-9A-Fa-f]{8}\-?[0-9A-Fa-f]{4}\-?[0-9A-Fa-f]{4}\-?[0-9A-Fa-f]{4}\-?[0-9A-Fa-f]{12}[})]?|PUT\-GUID\-(\d+\-)?HERE|([!$])(\(var|\(loc|\(wix)\.[_A-Za-z][0-9A-Za-z_.]*\)|\*|^$" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Integer">
+    <xs:annotation>
+      <xs:documentation>Values of this type must be a non-negative integer or a preprocessor variable with the format `$(Variable)` or `$(var.Variable)`.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[\d]+|\$\((var\.)?[_A-Za-z][0-9A-Za-z_.]*\)" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="LocalizableInteger">
+    <xs:annotation>
+      <xs:documentation>Values of this type must be a non-negative integer or a localization variable with the format `!(loc.Variable)` where `Variable` is the name of the localization variable.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[\d]+|\$\((var\.)?[_A-Za-z][_A-Za-z0-9.]*\)|!\((loc|bind)\.[_A-Za-z][_A-Za-z0-9.]*\)" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="NegativeInteger">
+    <xs:annotation>
+      <xs:documentation>Values of this allow negative integer or a preprocessor variable with the format `$(Variable)` or `$(var.Variable).</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="-?[\d]+|\$\((var\.)?[_A-Za-z][0-9A-Za-z_.]*\)" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ShortFileNameType">
+    <xs:annotation>
+      <xs:documentation>Values of this type will look like: "FileName.ext". Only one period is allowed. The following characters are not allowed: \ ? | &gt; : / * " + , ; = [ ] &lt;, or whitespace. The name cannot exceed 8 characters and the extension cannot exceed 3 characters. The value could also be a localization variable with the format !(loc.VARIABLE).</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[^\\\?|&gt;&lt;:/\*&quot;\+,;=\[\]\. ]{1,8}(\.[^\\\?|&gt;&lt;:/\*&quot;\+,;=\[\]\. ]{0,3})?|([!$])\(loc\.[_A-Za-z][0-9A-Za-z_.]*\)" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="LongFileNameType">
+    <xs:annotation>
+      <xs:documentation>Values of this type will look like: "Long File Name.extension". Legal long names contain no more than 260 characters and must contain at least one non-period character. The following characters are not allowed: \ ? | &gt; : / * " or &lt;. The name must be shorter than 260 characters. The value could also be a localization variable with the format !(loc.VARIABLE).</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[^\\\?|&gt;&lt;:/\*&quot;]{1,259}|([!$])\(loc\.[_A-Za-z][0-9A-Za-z_.]*\)" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="VersionType">
+    <xs:annotation>
+      <xs:documentation>Values of this type will look like: "x.x.x.x" where x is an integer from 0 to 65534.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(\d{1,5}\.){3}\d{1,5}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StrictThreePartVersionType">
+    <xs:annotation>
+      <xs:documentation>Values of this type will look exactly like: "x.x.x" where x is an integer.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(\d+\.){2}\d+|\$\((var\.)?[_A-Za-z][0-9A-Za-z_.]*\)|!\((loc|bind)\.[_A-Za-z][_A-Za-z0-9.]*\)" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="WixVersionType">
+    <xs:annotation>
+      <xs:documentation>Values of this type will be a 1-part, 2-part, 3-part or 4-part version number or a semantic version.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="v?(\d+\.){0,3}\d+(-[\w.\d]+)?||\$\((var\.)?[_A-Za-z][_A-Za-z0-9.]*\)|!\((loc|bind)\.[_A-Za-z][_A-Za-z0-9.]*\)" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="WildCardShortFileNameType">
+    <xs:annotation>
+      <xs:documentation>Values of this type will look like: "File?.*". Only one period is allowed. The following characters are not allowed: \ | &gt; : / " + , ; = [ ] &lt;, or whitespace. The name cannot be longer than 8 characters and the extension cannot exceed 3 characters. The value could also be a localization variable with the format !(loc.VARIABLE).</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[^\\\|&gt;&lt;:/&quot;\+,;=\[\]\. ]{1,16}(\.[^\\\|&gt;&lt;:/&quot;\+,;=\[\]\. ]{0,6})?|([!$])\(loc\.[_A-Za-z][0-9A-Za-z_.]*\)" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="WildCardLongFileNameType">
+    <xs:annotation>
+      <xs:documentation>Values of this type will look like: "Long File N?me.extension*". Legal long names contain no more than 260 characters and must contain at least one non-period character. The following characters are not allowed: \ | &gt; : / " or &lt;. The name must be shorter than 260 characters. The value could also be a localization variable with the format !(loc.VARIABLE).</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[^\\\|&gt;&lt;:/&quot;]{1,259}|([!$])\(loc\.[_A-Za-z][0-9A-Za-z_.]*\)" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="HexType">
+    <xs:annotation>
+      <xs:documentation>This type supports any hexadecimal number. Both upper and lower case are supported for letters appearing in the number. This type also includes the empty string: "".</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[0-9A-Fa-f]*" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="StandardDirectoryTypeUnion">
+    <xs:annotation>
+      <xs:documentation>A Windows Installer standard directory.</xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="StandardDirectoryType PreprocessorVariables"/>
+  </xs:simpleType>
+  <xs:simpleType name="StandardDirectoryType">
+    <xs:annotation>
+      <xs:documentation>A Windows Installer standard directory.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="TARGETDIR" />
+      <xs:enumeration value="AdminToolsFolder" />
+      <xs:enumeration value="AppDataFolder" />
+      <xs:enumeration value="CommonAppDataFolder" />
+      <xs:enumeration value="CommonFilesFolder" />
+      <xs:enumeration value="CommonFiles64Folder" />
+      <xs:enumeration value="CommonFiles6432Folder" />
+      <xs:enumeration value="DesktopFolder" />
+      <xs:enumeration value="FavoritesFolder" />
+      <xs:enumeration value="FontsFolder" />
+      <xs:enumeration value="LocalAppDataFolder" />
+      <xs:enumeration value="MyPicturesFolder" />
+      <xs:enumeration value="NetHoodFolder" />
+      <xs:enumeration value="PersonalFolder" />
+      <xs:enumeration value="PrintHoodFolder" />
+      <xs:enumeration value="ProgramFilesFolder" />
+      <xs:enumeration value="ProgramFiles64Folder" />
+      <xs:enumeration value="ProgramFiles6432Folder" />
+      <xs:enumeration value="ProgramMenuFolder" />
+      <xs:enumeration value="RecentFolder" />
+      <xs:enumeration value="SendToFolder" />
+      <xs:enumeration value="StartMenuFolder" />
+      <xs:enumeration value="StartupFolder" />
+      <xs:enumeration value="SystemFolder" />
+      <xs:enumeration value="System16Folder" />
+      <xs:enumeration value="System64Folder" />
+      <xs:enumeration value="System6432Folder" />
+      <xs:enumeration value="TempFolder" />
+      <xs:enumeration value="TemplateFolder" />
+      <xs:enumeration value="WindowsFolder" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PackageScopeTypeUnion">
+    <xs:annotation>
+      <xs:documentation>Use this attribute to specify the installation scope of this package: per-machine, per-user, or a choice of either.</xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="PackageScopeType PreprocessorVariables"/>
+  </xs:simpleType>
+  <xs:simpleType name="PackageScopeType">
+    <xs:annotation>
+      <xs:documentation>Use this attribute to specify the installation scope of this package: per-machine, per-user, or a choice of either.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="perMachine">
+        <xs:annotation>
+          <xs:documentation>
+            Set this value to declare that the package is a per-machine installation and requires elevated privileges to install.
+            Sets the ALLUSERS property to 1.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="perUser">
+        <xs:annotation>
+          <xs:documentation>
+            Set this value to declare that the package is a per-user installation and does not require elevated privileges to install.
+            Sets the package's InstallPrivileges attribute to "limited."
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="perUserOrMachine">
+        <xs:annotation>
+          <xs:documentation>
+            Set this value to declare that the package is [dual-purpose that can install per-user or per-machine](https://learn.microsoft.com/en-us/windows/win32/msi/single-package-authoring).
+            Sets the ALLUSERS property to 2 and MSIINSTALLPERUSER property to 1.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="YesNoTypeUnion">
+    <xs:annotation>
+      <xs:documentation>Values of this type will either be "yes"/"true" or "no"/"false".</xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="YesNoType PreprocessorVariables"/>
+  </xs:simpleType>
+  <xs:simpleType name="YesNoType">
+    <xs:annotation>
+      <xs:documentation>Values of this type will either be "yes"/"true" or "no"/"false".</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="no" />
+      <xs:enumeration value="false" />
+      <xs:enumeration value="yes" />
+      <xs:enumeration value="true" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="YesNoButtonTypeUnion">
+    <xs:annotation>
+      <xs:documentation>Values of this type will either be "button", "yes"/"true", or "no"/"false".</xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="YesNoButtonType PreprocessorVariables"/>
+  </xs:simpleType>
+  <xs:simpleType name="YesNoButtonType">
+    <xs:annotation>
+      <xs:documentation>Values of this type will either be "button", "yes"/"true", or "no"/"false".</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="no" />
+      <xs:enumeration value="false" />
+      <xs:enumeration value="yes" />
+      <xs:enumeration value="true" />
+      <xs:enumeration value="button" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="YesNoDefaultTypeUnion">
+    <xs:annotation>
+      <xs:documentation>Values of this type will either be "default", "yes", or "no".</xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="YesNoDefaultType PreprocessorVariables"/>
+  </xs:simpleType>
+  <xs:simpleType name="YesNoDefaultType">
+    <xs:annotation>
+      <xs:documentation>Values of this type will either be "default", "yes", or "no".</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="default" />
+      <xs:enumeration value="no" />
+      <xs:enumeration value="false" />
+      <xs:enumeration value="yes" />
+      <xs:enumeration value="true" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="KeepRemoveForceTypeUnion">
+    <xs:annotation>
+      <xs:documentation>Values of this type will either be "force", "keep", or "remove".</xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="KeepRemoveForceType PreprocessorVariables"/>
+  </xs:simpleType>
+  <xs:simpleType name="KeepRemoveForceType">
+    <xs:annotation>
+      <xs:documentation>Values of this type will either be "force", "keep", or "remove".</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="force">
+        <xs:annotation>
+          <xs:documentation>
+            Always cache the package during Cache, Install, Modify, Repair, and Layout.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="keep">
+        <xs:annotation>
+          <xs:documentation>
+            Keep the package cached when the package is requested to be present.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="remove">
+        <xs:annotation>
+          <xs:documentation>
+            Always uncache the package after Cache, Install, Modify, Repair, Uninstall, and Layout.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="RegistryRootType">
+    <xs:annotation>
+      <xs:documentation>Values of this type represent possible registry roots.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="HKMU">
+        <xs:annotation>
+          <xs:documentation>
+                        A per-user installation will make the operation occur under HKEY_CURRENT_USER.
+                        A per-machine installation will make the operation occur under HKEY_LOCAL_MACHINE.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="HKCR">
+        <xs:annotation>
+          <xs:documentation>
+                        Operation occurs under HKEY_CLASSES_ROOT. When using Windows 2000 or later, the installer writes or removes the value
+                        from the HKCU\Software\Classes hive during per-user installations. When using Windows 2000 or later operating systems,
+                        the installer writes or removes the value from the HKLM\Software\Classes hive during per-machine installations.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="HKCU">
+        <xs:annotation>
+          <xs:documentation>
+                        Operation occurs under HKEY_CURRENT_USER. It is recommended to set the KeyPath attribute to `yes` when setting this value for writing values
+                        in order to ensure that the installer writes the necessary registry entries when there are multiple users on the same computer.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="HKLM">
+        <xs:annotation>
+          <xs:documentation>
+                        Operation occurs under HKEY_LOCAL_MACHINE.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="HKU">
+        <xs:annotation>
+          <xs:documentation>
+                        Operation occurs under HKEY_USERS.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ExitType">
+    <xs:annotation>
+      <xs:documentation>Value indicates that this action is executed if the installer returns the associated exit type. Each exit type can be used with no more than one action.
+                        Multiple actions can have exit types assigned, but every action and exit type must be different. Exit types are typically used with dialog boxes.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="success" />
+      <xs:enumeration value="cancel" />
+      <xs:enumeration value="error" />
+      <xs:enumeration value="suspend" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="InstallUninstallType">
+    <xs:annotation>
+      <xs:documentation>Specifies whether an action occur on install, uninstall or both.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="install">
+        <xs:annotation>
+          <xs:documentation>
+                        The action should happen during install (msiInstallStateLocal or msiInstallStateSource).
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="uninstall">
+        <xs:annotation>
+          <xs:documentation>
+                        The action should happen during uninstall (msiInstallStateAbsent).
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="both">
+        <xs:annotation>
+          <xs:documentation>
+                        The action should happen during both install and uninstall.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SequenceType">
+    <xs:annotation>
+      <xs:documentation>
+                Controls which sequences the item assignment is sequenced in.
+            </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="both">
+        <xs:annotation>
+          <xs:documentation>
+                        Schedules the assignment in the InstallUISequence and the InstallExecuteSequence.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="first">
+        <xs:annotation>
+          <xs:documentation>
+                        Schedules the assignment to run in the InstallUISequence or the InstallExecuteSequence if the InstallUISequence is skipped.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="execute">
+        <xs:annotation>
+          <xs:documentation>
+                        Schedules the assignment only in the the InstallExecuteSequence.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ui">
+        <xs:annotation>
+          <xs:documentation>
+                        Schedules the assignment only in the the InstallUISequence.
+                    </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CompressionLevelTypeUnion">
+    <xs:annotation>
+      <xs:documentation>
+        Indicates the compression level for a cabinet.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="CompressionLevelType PreprocessorVariables"/>
+  </xs:simpleType>
+
+  <xs:simpleType name="CompressionLevelType">
+    <xs:annotation>
+      <xs:documentation>
+        Indicates the compression level for a cabinet.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="high" />
+      <xs:enumeration value="low" />
+      <xs:enumeration value="medium" />
+      <xs:enumeration value="mszip" />
+      <xs:enumeration value="none" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="PreprocessorVariables">
+    <xs:annotation>
+      <xs:documentation>A type that represents that 1 or more preprocessor variables (as they appear in sources on disk, before preprocessor has run).</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(\$\((\w+\.)?(\w[\w()]*)\))+" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DiskIdType">
+    <xs:annotation>
+      <xs:documentation>Values of this type must be an integer or the value of one or more preprocessor variables with the format `$(Variable)` or `$(var.Variable)`.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="((\d+)|(\$\(\w+\.(\w|[.])+\)))+" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="VariableType">
+    <xs:annotation>
+      <xs:documentation>Indicates the type of a Variable.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:NMTOKEN">
+      <xs:enumeration value="string">
+        <xs:annotation>
+          <xs:documentation>A literal string.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="formatted">
+        <xs:annotation>
+          <xs:documentation>A string that may contain Variables.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="numeric" />
+      <xs:enumeration value="version" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="Provides">
+    <xs:annotation>
+      <xs:documentation>
+        Describes the information for this product or feature that serves as a dependency of other products or features.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:remarks>
+          This element is required for any product, feature, or bundle that will use the Dependency feature to properly reference count
+          other products or features. It should be authored into a component that is always installed and removed with the
+          product or features that contain it. This guarantees that product dependencies are not removed before those products that
+          depend on them.
+
+          The @Key attribute should identify a version range for your product that you guarantee will be backward compatible.
+          This key is designed to persist throughout compatible upgrades so that dependent products do not have to be reinstalled
+          and will not prevent your product from being upgraded. If this attribute is not authored, the value is the ProductCode
+          and will not automatically support upgrades.
+
+          By default this uses the Package/@ProductCode attribute value, which may be automatically generated.
+        </xse:remarks>
+        <xse:howtoRef href="author_product_dependencies.html">How To: Author product dependencies</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="Requires" />
+        <xs:element ref="RequiresRef" />
+      </xs:choice>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Dependency provider identity. If this attribute is not specified, an identifier will be generated automatically.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Key" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Optional unique registry key name that identifies a product version range on which other products can depend.
+            This attribute is required in package authoring, but optional for components.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Version" type="WixVersionType">
+        <xs:annotation>
+          <xs:documentation>
+            The version of the package. For MSI packages, the ProductVersion will be used by default
+            and this attribute should not be specified.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="DisplayName" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Optional display name of the package. For MSI packages, the ProductName will be used by default.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Requires">
+    <xs:annotation>
+      <xs:documentation>
+        Describes a dependency on a provider for the current component or package.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:remarks>
+          <html:p>
+            This element declares a dependency on any product that uses the Provides element. If that product is uninstalled
+            before a product that requires it, the uninstall will err or warn the user that other products are installed
+            which depend on that product. This behavior can be modified by changing the attribute values on the Requires element.
+          </html:p>
+          <html:p>
+            If you do not nest this element under a Provides element, you must specify the @Id attribute
+            so that it can be referenced by a RequiresRef element nested under a Provides element.
+          </html:p>
+        </xse:remarks>
+        <xse:seeAlso ref="RequiresRef" />
+        <xse:howtoRef href="author_product_dependencies.html">How To: Author product dependencies</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Dependency requirement identity. If this attribute is not specified, an identifier will be generated automatically.
+            If this element is not authored under a Provides element, this attribute is required.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="ProviderKey" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The unique registry key name for the dependency provider to require during installation of this product.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Minimum" type="WixVersionType">
+        <xs:annotation>
+          <xs:documentation>
+            The minimum version of the dependency provider required to be installed. The default is unbound.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Maximum" type="WixVersionType">
+        <xs:annotation>
+          <xs:documentation>
+            The maximum version of the dependency provider required to be installed. The default is unbound.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IncludeMinimum" type="YesNoType">
+        <xs:annotation>
+          <xs:documentation>
+            Set to "yes" to make the range of dependency provider versions required include the value specified in Minimum.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="IncludeMaximum" type="YesNoType">
+        <xs:annotation>
+          <xs:documentation>
+            Set to "yes" to make the range of dependency provider versions required include the value specified in Maximum.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="RequiresRef">
+    <xs:annotation>
+      <xs:documentation>
+        References existing authoring for a dependency on a provider for the current component or package.
+      </xs:documentation>
+      <xs:appinfo>
+        <xse:remarks>
+          <html:p>
+            This element references a dependency on any product that uses the Provides element. If that product is uninstalled
+            before a product that requires it, the uninstall will err or warn the user that other products are installed
+            which depend on that product. This behavior can be modified by changing the attribute values on the Requires element.
+          </html:p>
+        </xse:remarks>
+        <xse:seeAlso ref="Requires" />
+        <xse:howtoRef href="author_product_dependencies.html">How To: Author product dependencies</xse:howtoRef>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="Id" type="xs:string" use="required">
+        <xs:annotation>
+          <xs:documentation>
+            The identifier of the Requires element to reference.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:anyAttribute namespace="##other" processContents="lax">
+        <xs:annotation>
+          <xs:documentation>
+            Extensibility point in the WiX XML Schema. Schema extensions can register additional attributes at this point in the schema.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:anyAttribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
Fixes #40

With these code changes I'm able to:
1. Set the Wix Binaries Directory to a directory which contains files from the Wix NuGet package.
For example:
a. Run `dotnet tool install --global wix --version 4.0.2` to download and install the WiX 4.0.2 tools.
b. Tools > Options > WiX Binaries Directory > `%userprofile%\.dotnet\tools\.store\wix\4.0.2\wix\4.0.2`
2. Load a Wix 4 wxs file
For example, `.\sample\SimpleSample_WiX4\SimpleSample.wxs`
3. Build > Build MSI setup package